### PR TITLE
fix(验证模块): 修复玩家无敌状态，添加超时取消机制

### DIFF
--- a/src/main/java/firefly520/fireflymc/ModEventHandler.java
+++ b/src/main/java/firefly520/fireflymc/ModEventHandler.java
@@ -8,10 +8,17 @@ import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
 
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
 /**
  * 全局事件处理器
  */
 public class ModEventHandler {
+
+    // 跟踪玩家的无敌超时任务（UUID -> 任务）
+    private static final Map<UUID, Thread> INVULNERABILITY_TIMEOUT_THREADS = new ConcurrentHashMap<>();
 
     public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
         if (event.getEntity() instanceof ServerPlayer serverPlayer) {
@@ -29,6 +36,27 @@ public class ModEventHandler {
 
             // 设置玩家无敌（客户端确认后会取消）
             serverPlayer.setInvulnerable(true);
+
+            // 添加超时保护：10秒后强制取消无敌状态
+            // 这是为了防止从单人游戏切换到多人游戏时，网络状态异常导致确认包丢失
+            UUID playerUuid = serverPlayer.getUUID();
+            Thread timeoutThread = new Thread(() -> {
+                try {
+                    Thread.sleep(10000); // 10秒超时
+                    serverPlayer.server.execute(() -> {
+                        ServerPlayer player = serverPlayer.server.getPlayerList().getPlayer(playerUuid);
+                        if (player != null && !ModPayloadHandler.CONFIRMED_PLAYERS.getOrDefault(playerUuid, false)) {
+                            // 玩家仍在游戏且未确认，强制取消无敌
+                            player.setInvulnerable(false);
+                        }
+                        INVULNERABILITY_TIMEOUT_THREADS.remove(playerUuid);
+                    });
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+            timeoutThread.start();
+            INVULNERABILITY_TIMEOUT_THREADS.put(playerUuid, timeoutThread);
 
             // 5秒后检查验证状态
             new Thread(() -> {
@@ -53,8 +81,22 @@ public class ModEventHandler {
 
     public static void onPlayerLoggedOut(PlayerEvent.PlayerLoggedOutEvent event) {
         if (event.getEntity() instanceof ServerPlayer serverPlayer) {
-            ModPayloadHandler.VERIFIED_PLAYERS.remove(serverPlayer.getUUID());
-            ModPayloadHandler.CONFIRMED_PLAYERS.remove(serverPlayer.getUUID());
+            UUID playerUuid = serverPlayer.getUUID();
+            ModPayloadHandler.VERIFIED_PLAYERS.remove(playerUuid);
+            ModPayloadHandler.CONFIRMED_PLAYERS.remove(playerUuid);
+            // 清理超时任务
+            cancelInvulnerabilityTimeout(playerUuid);
+        }
+    }
+
+    /**
+     * 取消玩家的无敌超时任务
+     * 当玩家确认规则或退出游戏时调用
+     */
+    public static void cancelInvulnerabilityTimeout(UUID playerUuid) {
+        Thread thread = INVULNERABILITY_TIMEOUT_THREADS.remove(playerUuid);
+        if (thread != null && thread.isAlive()) {
+            thread.interrupt();
         }
     }
 }

--- a/src/main/java/firefly520/fireflymc/ModEventHandler.java
+++ b/src/main/java/firefly520/fireflymc/ModEventHandler.java
@@ -4,6 +4,7 @@ import firefly520.fireflymc.network.ModHandshakePayload;
 import firefly520.fireflymc.network.ModPayloadHandler;
 import firefly520.fireflymc.network.ShowRulesPayload;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.network.PacketDistributor;
@@ -11,25 +12,44 @@ import net.neoforged.neoforge.network.PacketDistributor;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 全局事件处理器
  */
 public class ModEventHandler {
 
-    // 跟踪玩家的无敌超时任务（UUID -> 任务）
-    private static final Map<UUID, Thread> INVULNERABILITY_TIMEOUT_THREADS = new ConcurrentHashMap<>();
+    /**
+     * 超时任务调度器（单线程守护线程池）
+     * 用于处理玩家无敌状态的超时取消
+     */
+    private static final ScheduledExecutorService TIMEOUT_EXECUTOR = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread t = new Thread(r, "FireflyMC-Invulnerability-Timeout");
+        t.setDaemon(true);
+        return t;
+    });
+
+    /**
+     * 跟踪玩家的无敌超时任务（UUID -> ScheduledFuture）
+     */
+    private static final Map<UUID, ScheduledFuture<?>> TIMEOUT_TASKS = new ConcurrentHashMap<>();
 
     public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
         if (event.getEntity() instanceof ServerPlayer serverPlayer) {
-            ModPayloadHandler.VERIFIED_PLAYERS.remove(serverPlayer.getUUID());
-            ModPayloadHandler.CONFIRMED_PLAYERS.remove(serverPlayer.getUUID());
+            UUID playerUuid = serverPlayer.getUUID();
+            MinecraftServer server = serverPlayer.server;
+
+            ModPayloadHandler.VERIFIED_PLAYERS.remove(playerUuid);
+            ModPayloadHandler.CONFIRMED_PLAYERS.remove(playerUuid);
 
             // 发送握手检测包
             PacketDistributor.sendToPlayer(serverPlayer, new ModHandshakePayload());
 
             // 判断是否首次加入（本次连接）
-            boolean isFirstJoin = !ModPayloadHandler.CONFIRMED_PLAYERS.containsKey(serverPlayer.getUUID());
+            boolean isFirstJoin = !ModPayloadHandler.CONFIRMED_PLAYERS.containsKey(playerUuid);
 
             // 发送显示准则弹窗包
             PacketDistributor.sendToPlayer(serverPlayer, new ShowRulesPayload(isFirstJoin));
@@ -38,44 +58,33 @@ public class ModEventHandler {
             serverPlayer.setInvulnerable(true);
 
             // 添加超时保护：10秒后强制取消无敌状态
-            // 这是为了防止从单人游戏切换到多人游戏时，网络状态异常导致确认包丢失
-            UUID playerUuid = serverPlayer.getUUID();
-            Thread timeoutThread = new Thread(() -> {
-                try {
-                    Thread.sleep(10000); // 10秒超时
-                    serverPlayer.server.execute(() -> {
-                        ServerPlayer player = serverPlayer.server.getPlayerList().getPlayer(playerUuid);
-                        if (player != null && !ModPayloadHandler.CONFIRMED_PLAYERS.getOrDefault(playerUuid, false)) {
-                            // 玩家仍在游戏且未确认，强制取消无敌
-                            player.setInvulnerable(false);
-                        }
-                        INVULNERABILITY_TIMEOUT_THREADS.remove(playerUuid);
-                    });
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                }
-            });
-            timeoutThread.start();
-            INVULNERABILITY_TIMEOUT_THREADS.put(playerUuid, timeoutThread);
+            // 防止从单人游戏切换到多人游戏时，网络状态异常导致确认包丢失
+            ScheduledFuture<?> timeoutTask = TIMEOUT_EXECUTOR.schedule(() -> {
+                server.execute(() -> {
+                    ServerPlayer player = server.getPlayerList().getPlayer(playerUuid);
+                    if (player != null && !ModPayloadHandler.CONFIRMED_PLAYERS.getOrDefault(playerUuid, false)) {
+                        player.setInvulnerable(false);
+                    }
+                    TIMEOUT_TASKS.remove(playerUuid);
+                });
+            }, 10, TimeUnit.SECONDS);
+            TIMEOUT_TASKS.put(playerUuid, timeoutTask);
 
             // 5秒后检查验证状态
-            new Thread(() -> {
-                try {
-                    Thread.sleep(5000);
-                    // 在主线程中执行检查
-                    serverPlayer.server.execute(() -> {
-                        if (!ModPayloadHandler.VERIFIED_PLAYERS.getOrDefault(serverPlayer.getUUID(), false)) {
-                            serverPlayer.connection.disconnect(Component.literal(
+            TIMEOUT_EXECUTOR.schedule(() -> {
+                server.execute(() -> {
+                    if (!ModPayloadHandler.VERIFIED_PLAYERS.getOrDefault(playerUuid, false)) {
+                        ServerPlayer player = server.getPlayerList().getPlayer(playerUuid);
+                        if (player != null) {
+                            player.connection.disconnect(Component.literal(
                                 "§c你未安装FireflyMC模组，无法进入本服务器！\n" +
                                 "请安装FireflyMC " + FireflyMCMod.VERSION + " 版本后重试。\n" +
                                 "§e下载地址: https://mc.firefly520.top"
                             ));
                         }
-                    });
-                } catch (InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }).start();
+                    }
+                });
+            }, 5, TimeUnit.SECONDS);
         }
     }
 
@@ -92,11 +101,13 @@ public class ModEventHandler {
     /**
      * 取消玩家的无敌超时任务
      * 当玩家确认规则或退出游戏时调用
+     *
+     * @param playerUuid 玩家UUID
      */
     public static void cancelInvulnerabilityTimeout(UUID playerUuid) {
-        Thread thread = INVULNERABILITY_TIMEOUT_THREADS.remove(playerUuid);
-        if (thread != null && thread.isAlive()) {
-            thread.interrupt();
+        ScheduledFuture<?> future = TIMEOUT_TASKS.remove(playerUuid);
+        if (future != null && !future.isDone()) {
+            future.cancel(false);
         }
     }
 }

--- a/src/main/java/firefly520/fireflymc/ModEventHandler.java
+++ b/src/main/java/firefly520/fireflymc/ModEventHandler.java
@@ -37,6 +37,11 @@ public class ModEventHandler {
      */
     private static final Map<UUID, ScheduledFuture<?>> TIMEOUT_TASKS = new ConcurrentHashMap<>();
 
+    /**
+     * 跟踪玩家的验证超时任务（UUID -> ScheduledFuture）
+     */
+    private static final Map<UUID, ScheduledFuture<?>> VERIFY_TASKS = new ConcurrentHashMap<>();
+
     public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
         if (event.getEntity() instanceof ServerPlayer serverPlayer) {
             UUID playerUuid = serverPlayer.getUUID();
@@ -71,7 +76,7 @@ public class ModEventHandler {
             TIMEOUT_TASKS.put(playerUuid, timeoutTask);
 
             // 5秒后检查验证状态
-            TIMEOUT_EXECUTOR.schedule(() -> {
+            ScheduledFuture<?> verifyTask = TIMEOUT_EXECUTOR.schedule(() -> {
                 server.execute(() -> {
                     if (!ModPayloadHandler.VERIFIED_PLAYERS.getOrDefault(playerUuid, false)) {
                         ServerPlayer player = server.getPlayerList().getPlayer(playerUuid);
@@ -83,8 +88,10 @@ public class ModEventHandler {
                             ));
                         }
                     }
+                    VERIFY_TASKS.remove(playerUuid);
                 });
             }, 5, TimeUnit.SECONDS);
+            VERIFY_TASKS.put(playerUuid, verifyTask);
         }
     }
 
@@ -95,6 +102,7 @@ public class ModEventHandler {
             ModPayloadHandler.CONFIRMED_PLAYERS.remove(playerUuid);
             // 清理超时任务
             cancelInvulnerabilityTimeout(playerUuid);
+            cancelVerifyTimeout(playerUuid);
         }
     }
 
@@ -106,6 +114,19 @@ public class ModEventHandler {
      */
     public static void cancelInvulnerabilityTimeout(UUID playerUuid) {
         ScheduledFuture<?> future = TIMEOUT_TASKS.remove(playerUuid);
+        if (future != null && !future.isDone()) {
+            future.cancel(false);
+        }
+    }
+
+    /**
+     * 取消玩家的验证超时任务
+     * 当玩家通过验证或退出游戏时调用
+     *
+     * @param playerUuid 玩家UUID
+     */
+    public static void cancelVerifyTimeout(UUID playerUuid) {
+        ScheduledFuture<?> future = VERIFY_TASKS.remove(playerUuid);
         if (future != null && !future.isDone()) {
             future.cancel(false);
         }

--- a/src/main/java/firefly520/fireflymc/network/ModPayloadHandler.java
+++ b/src/main/java/firefly520/fireflymc/network/ModPayloadHandler.java
@@ -1,6 +1,7 @@
 package firefly520.fireflymc.network;
 
 import firefly520.fireflymc.FireflyMCMod;
+import firefly520.fireflymc.ModEventHandler;
 import net.minecraft.network.chat.Component;
 import net.minecraft.server.level.ServerPlayer;
 import net.neoforged.neoforge.network.handling.IPayloadContext;
@@ -49,10 +50,13 @@ public class ModPayloadHandler {
     public static void handleConfirmRules(ConfirmRulesPayload payload, IPayloadContext context) {
         context.enqueueWork(() -> {
             if (context.player() instanceof ServerPlayer serverPlayer) {
+                UUID playerUuid = serverPlayer.getUUID();
+                // 取消超时任务
+                ModEventHandler.cancelInvulnerabilityTimeout(playerUuid);
                 // 取消玩家无敌
                 serverPlayer.setInvulnerable(false);
                 // 标记玩家已确认
-                CONFIRMED_PLAYERS.put(serverPlayer.getUUID(), true);
+                CONFIRMED_PLAYERS.put(playerUuid, true);
             }
         });
     }

--- a/src/main/java/firefly520/fireflymc/network/ModPayloadHandler.java
+++ b/src/main/java/firefly520/fireflymc/network/ModPayloadHandler.java
@@ -29,6 +29,8 @@ public class ModPayloadHandler {
             if (context.player() instanceof ServerPlayer serverPlayer) {
                 if (payload.modVersion().equals(FireflyMCMod.VERSION)) {
                     VERIFIED_PLAYERS.put(serverPlayer.getUUID(), true);
+                    // 取消验证超时任务
+                    ModEventHandler.cancelVerifyTimeout(serverPlayer.getUUID());
                 } else {
                     serverPlayer.connection.disconnect(Component.literal(
                         "§cFireflyMC模组版本不匹配！\n" +


### PR DESCRIPTION
- 添加玩家无敌超时保护线程，10秒后强制取消未确认玩家的无敌状态
- 在玩家登出时清理超时任务，避免资源泄漏
- 玩家确认规则时取消对应的超时任务
- 新增cancelInvulnerabilityTimeout方法统一管理超时任务取消逻辑
- 使用ConcurrentHashMap存储超时任务确保线程安全