### PR TITLE
Fix 2

### DIFF
--- a/src/main/java/firefly520/fireflymc/ModEventHandler.java
+++ b/src/main/java/firefly520/fireflymc/ModEventHandler.java
@@ -37,6 +37,11 @@ public class ModEventHandler {
      */
     private static final Map<UUID, ScheduledFuture<?>> TIMEOUT_TASKS = new ConcurrentHashMap<>();
 
+    /**
+     * 跟踪玩家的验证超时任务（UUID -> ScheduledFuture）
+     */
+    private static final Map<UUID, ScheduledFuture<?>> VERIFY_TASKS = new ConcurrentHashMap<>();
+
     public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
         if (event.getEntity() instanceof ServerPlayer serverPlayer) {
             UUID playerUuid = serverPlayer.getUUID();
@@ -71,7 +76,7 @@ public class ModEventHandler {
             TIMEOUT_TASKS.put(playerUuid, timeoutTask);
 
             // 5秒后检查验证状态
-            TIMEOUT_EXECUTOR.schedule(() -> {
+            ScheduledFuture<?> verifyTask = TIMEOUT_EXECUTOR.schedule(() -> {
                 server.execute(() -> {
                     if (!ModPayloadHandler.VERIFIED_PLAYERS.getOrDefault(playerUuid, false)) {
                         ServerPlayer player = server.getPlayerList().getPlayer(playerUuid);
@@ -83,8 +88,10 @@ public class ModEventHandler {
                             ));
                         }
                     }
+                    VERIFY_TASKS.remove(playerUuid);
                 });
             }, 5, TimeUnit.SECONDS);
+            VERIFY_TASKS.put(playerUuid, verifyTask);
         }
     }
 
@@ -95,6 +102,7 @@ public class ModEventHandler {
             ModPayloadHandler.CONFIRMED_PLAYERS.remove(playerUuid);
             // 清理超时任务
             cancelInvulnerabilityTimeout(playerUuid);
+            cancelVerifyTimeout(playerUuid);
         }
     }
 
@@ -106,6 +114,19 @@ public class ModEventHandler {
      */
     public static void cancelInvulnerabilityTimeout(UUID playerUuid) {
         ScheduledFuture<?> future = TIMEOUT_TASKS.remove(playerUuid);
+        if (future != null && !future.isDone()) {
+            future.cancel(false);
+        }
+    }
+
+    /**
+     * 取消玩家的验证超时任务
+     * 当玩家通过验证或退出游戏时调用
+     *
+     * @param playerUuid 玩家UUID
+     */
+    public static void cancelVerifyTimeout(UUID playerUuid) {
+        ScheduledFuture<?> future = VERIFY_TASKS.remove(playerUuid);
         if (future != null && !future.isDone()) {
             future.cancel(false);
         }

--- a/src/main/java/firefly520/fireflymc/network/ModPayloadHandler.java
+++ b/src/main/java/firefly520/fireflymc/network/ModPayloadHandler.java
@@ -29,6 +29,8 @@ public class ModPayloadHandler {
             if (context.player() instanceof ServerPlayer serverPlayer) {
                 if (payload.modVersion().equals(FireflyMCMod.VERSION)) {
                     VERIFIED_PLAYERS.put(serverPlayer.getUUID(), true);
+                    // 取消验证超时任务
+                    ModEventHandler.cancelVerifyTimeout(serverPlayer.getUUID());
                 } else {
                     serverPlayer.connection.disconnect(Component.literal(
                         "§cFireflyMC模组版本不匹配！\n" +


### PR DESCRIPTION
- 新增 VERIFY_TASKS 映射跟踪玩家验证超时任务
- 在 ModEventHandler 中添加 cancelVerifyTimeout 方法用于取消验证任务
- 玩家成功验证时调用 cancelVerifyTimeout 清理任务
- 玩家退出游戏时同步清理验证超时任务
- 优化验证逻辑，避免任务泄漏和资源浪费