### PR TITLE
feat(ai): 支持服务器终端执行AI聊天命令并优化权限检查

### DIFF
--- a/src/main/java/firefly520/fireflymc/ai/AIChatEventHandler.java
+++ b/src/main/java/firefly520/fireflymc/ai/AIChatEventHandler.java
@@ -143,19 +143,12 @@ public class AIChatEventHandler {
         var source = context.getSource();
         var player = source.getPlayer();
 
-        if (player == null) {
-            source.sendFailure(Component.literal("§c该命令只能由玩家执行"));
-            return 0;
-        }
-
         // 检查是否多人服务器
-        if (!isMultiplayerServer(player.getServer())) {
+        MinecraftServer server = player != null ? player.getServer() : source.getServer();
+        if (!isMultiplayerServer(server)) {
             source.sendFailure(Component.literal("§cAI聊天仅在多人服务器可用"));
             return 0;
         }
-
-        var server = player.getServer();
-        var historyManager = getHistoryManager(server);
 
         // 获取命令参数（消息内容）
         String prompt = StringArgumentType.getString(context, "message");
@@ -165,38 +158,50 @@ public class AIChatEventHandler {
             return 1;
         }
 
-        // 检查冷却时间
-        if (isOnCooldown(player)) {
-            long elapsed = (System.currentTimeMillis() -
-                    PLAYER_COOLDOWNS.get(player.getUUID())) / 1000;
-            long remaining = AIConfig.getCooldownSeconds() - elapsed;
+        var historyManager = getHistoryManager(server);
 
-            player.sendSystemMessage(Component.literal(
-                    "§c请等待 " + remaining + " 秒后再试~"
+        if (player != null) {
+            // 玩家执行路径（保持原有逻辑）
+            // 检查冷却时间
+            if (isOnCooldown(player)) {
+                long elapsed = (System.currentTimeMillis() -
+                        PLAYER_COOLDOWNS.get(player.getUUID())) / 1000;
+                long remaining = AIConfig.getCooldownSeconds() - elapsed;
+
+                player.sendSystemMessage(Component.literal(
+                        "§c请等待 " + remaining + " 秒后再试~"
+                ));
+                return 0;
+            }
+
+            // 记录触发时间
+            recordTrigger(player);
+
+            // 记录玩家消息到历史
+            historyManager.addMessage(new ChatMessage(
+                    player.getName().getString(),
+                    prompt,
+                    MessageType.PLAYER
             ));
-            return 0;
+
+            // 广播玩家消息到聊天区（与普通聊天格式一致）
+            broadcastPlayerMessage(server, player.getName().getString(), prompt);
+
+            // 发送WebSocket广播（玩家聊天消息）
+            PlayerEventWebSocketClient.sendEvent(
+                    PlayerEventMessage.playerChat(player.getName().getString(), prompt)
+            );
+
+            // 异步调用AI
+            callAIAsync(server, player, historyManager, prompt, false);
+        } else {
+            // 终端执行路径（新增，跳过冷却）
+            String senderName = "Server Console";
+            historyManager.addMessage(new ChatMessage(senderName, prompt, MessageType.PLAYER));
+            source.sendSuccess(() -> Component.literal("§a[Server Console] " + prompt), true);
+            PlayerEventWebSocketClient.sendEvent(PlayerEventMessage.playerChat(senderName, prompt));
+            callAIAsyncConsole(source.getServer(), historyManager, prompt);
         }
-
-        // 记录触发时间
-        recordTrigger(player);
-
-        // 记录玩家消息到历史
-        historyManager.addMessage(new ChatMessage(
-                player.getName().getString(),
-                prompt,
-                MessageType.PLAYER
-        ));
-
-        // 广播玩家消息到聊天区（与普通聊天格式一致）
-        broadcastPlayerMessage(server, player.getName().getString(), prompt);
-
-        // 发送WebSocket广播（玩家聊天消息）
-        PlayerEventWebSocketClient.sendEvent(
-                PlayerEventMessage.playerChat(player.getName().getString(), prompt)
-        );
-
-        // 异步调用AI
-        callAIAsync(server, player, historyManager, prompt, false);
 
         return 1;
     }
@@ -753,6 +758,84 @@ public class AIChatEventHandler {
                 }
             });
         });
+    }
+
+    /**
+     * 异步调用AI API（服务器终端触发版本）
+     */
+    private static void callAIAsyncConsole(MinecraftServer server,
+                                           ChatHistoryManager historyManager,
+                                           String prompt) {
+        CompletableFuture.supplyAsync(() -> {
+            // 异步线程：执行网络请求
+            var history = List.copyOf(historyManager.getHistory());
+            List<AIFunctionTool> tools = AIConfig.getFunctionsEnabled()
+                    ? new java.util.ArrayList<>(FunctionToolRegistry.getAllTools())
+                    : null;
+            return AIApiClient.callAIWithFunctions(history, prompt, "Server Console", tools);
+        }).thenAccept(response -> {
+            // 回到主线程：发送游戏消息
+            server.execute(() -> {
+                if (!response.isSuccess()) {
+                    LOGGER.error("[FireflyMC] 终端AI请求失败: {}", response.errorType());
+                    return;
+                }
+
+                if (response.hasToolCalls()) {
+                    handleToolCallsConsole(server, historyManager, response.toolCalls());
+                } else if (response.content() != null && !response.content().isEmpty()) {
+                    broadcastReplyNoPlayer(server, response.content());
+                    historyManager.addMessage(new ChatMessage(
+                            AIConfig.getAiNamePlain(),
+                            response.content(),
+                            MessageType.ASSISTANT
+                    ));
+                }
+            });
+        });
+    }
+
+    /**
+     * 处理AI返回的工具调用（服务器终端版本，4级OP权限）
+     */
+    private static void handleToolCallsConsole(MinecraftServer server,
+                                               ChatHistoryManager historyManager,
+                                               java.util.List<FunctionCallRequest> toolCalls) {
+        if (toolCalls.isEmpty()) {
+            return;
+        }
+
+        var call = toolCalls.get(0);
+
+        // 终端始终具有4级OP权限，跳过权限检查
+        FunctionToolRegistry.getTool(call.name()).ifPresent(tool -> {
+            FunctionCallResult result = tool.execute(server, call.arguments());
+            sendToolCallResultToAIConsole(server, historyManager, call.id(), result);
+        });
+
+        // 继续调用AI获取最终回复
+        callAIAsyncConsole(server, historyManager,
+                   "[函数调用已完成，请根据结果回复]");
+    }
+
+    /**
+     * 将工具执行结果发送给AI（服务器终端版本）
+     */
+    private static void sendToolCallResultToAIConsole(MinecraftServer server,
+                                                      ChatHistoryManager historyManager,
+                                                      String callId, FunctionCallResult result) {
+        String resultMessage;
+        if (result.isSuccess()) {
+            resultMessage = "工具调用成功：" + result.getMessage();
+        } else {
+            resultMessage = "工具调用失败：" + result.getMessage();
+        }
+
+        historyManager.addMessage(new ChatMessage(
+                "System",
+                resultMessage,
+                MessageType.SYSTEM
+        ));
     }
 
     /**

--- a/src/main/java/firefly520/fireflymc/ai/AIFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/AIFunctionTool.java
@@ -1,6 +1,7 @@
 package firefly520.fireflymc.ai;
 
 import com.google.gson.JsonObject;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 
 /**
@@ -47,13 +48,28 @@ public interface AIFunctionTool {
     int getRequiredPermissionLevel();
 
     /**
-     * 执行函数
-     * <p>
-     * 当AI决定调用此函数时，此方法将被调用
+     * 执行函数（玩家触发）
      *
      * @param player    触发此函数调用的玩家（用于权限验证）
      * @param arguments AI传递的函数参数
      * @return 执行结果
      */
     FunctionCallResult execute(ServerPlayer player, JsonObject arguments);
+
+    /**
+     * 执行函数（服务器控制台触发）
+     * <p>
+     * 从控制台触发时具有最高权限（4级OP），无需玩家上下文。
+     * 默认实现返回不支持提示，需要各工具自行覆写以支持控制台调用。
+     *
+     * @param server    Minecraft服务器实例
+     * @param arguments AI传递的函数参数
+     * @return 执行结果
+     */
+    default FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        return FunctionCallResult.failure(
+                FunctionCallResult.ErrorType.EXECUTION_FAILED,
+                "此工具不支持从服务器控制台调用"
+        );
+    }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/ClearInventoryFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/ClearInventoryFunctionTool.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.ItemStack;
 
@@ -158,5 +159,72 @@ public class ClearInventoryFunctionTool implements AIFunctionTool {
         return FunctionCallResult.success(
                 String.format("已清除 %s 的 %s，共清除 %d 件物品", targetName, slotDesc, clearedCount)
         );
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        if (!arguments.has("targetPlayer")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "从控制台执行必须指定 targetPlayer");
+        }
+
+        var playerResult = FunctionToolHelper.getRequiredTargetPlayer(server, arguments, "targetPlayer");
+        if (playerResult.hasError()) return playerResult.error();
+
+        ServerPlayer targetPlayer = playerResult.player();
+        String targetName = arguments.get("targetPlayer").getAsString();
+
+        String slot = FunctionToolHelper.getOptionalString(arguments, "slot", "all");
+        if (!slot.matches("all|hotbar|inventory|armor")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT,
+                    "无效的清除范围: " + slot + "。支持: all, hotbar, inventory, armor");
+        }
+
+        int clearedCount = switch (slot) {
+            case "all" -> {
+                int containerSize = targetPlayer.getInventory().getContainerSize();
+                int count = 0;
+                for (int i = 0; i < containerSize; i++) {
+                    if (!targetPlayer.getInventory().getItem(i).isEmpty()) count++;
+                }
+                targetPlayer.getInventory().clearContent();
+                yield count;
+            }
+            case "hotbar" -> {
+                int count = 0;
+                for (int i = 0; i < 9; i++) {
+                    if (!targetPlayer.getInventory().getItem(i).isEmpty()) count++;
+                    targetPlayer.getInventory().setItem(i, ItemStack.EMPTY);
+                }
+                yield count;
+            }
+            case "inventory" -> {
+                int count = 0;
+                for (int i = 9; i < 36; i++) {
+                    if (!targetPlayer.getInventory().getItem(i).isEmpty()) count++;
+                    targetPlayer.getInventory().setItem(i, ItemStack.EMPTY);
+                }
+                yield count;
+            }
+            case "armor" -> {
+                int count = 0;
+                for (int i = 36; i < 40; i++) {
+                    if (!targetPlayer.getInventory().getItem(i).isEmpty()) count++;
+                    targetPlayer.getInventory().setItem(i, ItemStack.EMPTY);
+                }
+                yield count;
+            }
+            default -> 0;
+        };
+
+        String slotDesc = switch (slot) {
+            case "all" -> "全部物品";
+            case "hotbar" -> "快捷栏";
+            case "inventory" -> "背包";
+            case "armor" -> "装备栏";
+            default -> slot;
+        };
+
+        return FunctionCallResult.success(
+                String.format("已清除 %s 的 %s，共清除 %d 件物品", targetName, slotDesc, clearedCount));
     }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/FunctionToolHelper.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/FunctionToolHelper.java
@@ -86,6 +86,39 @@ public class FunctionToolHelper {
     }
 
     /**
+     * 从服务器获取必需的目标玩家（控制台版本，无默认玩家）
+     *
+     * @param server    Minecraft服务器实例
+     * @param arguments 参数对象
+     * @param paramName 目标玩家参数名（如 "targetPlayer"）
+     * @return 包含目标玩家的结果
+     */
+    public static PlayerResult getRequiredTargetPlayer(MinecraftServer server, JsonObject arguments, String paramName) {
+        var nameResult = getRequiredString(arguments, paramName);
+        if (nameResult.hasError()) {
+            return new PlayerResult(null, nameResult.error());
+        }
+        String targetName = nameResult.value();
+        ServerPlayer targetPlayer = server.getPlayerList().getPlayerByName(targetName);
+        if (targetPlayer == null) {
+            return new PlayerResult(null, FunctionCallResult.failure(
+                    FunctionCallResult.ErrorType.EXECUTION_FAILED,
+                    "玩家 " + targetName + " 不在线"
+            ));
+        }
+        return new PlayerResult(targetPlayer, null);
+    }
+
+    /**
+     * 玩家结果包装类
+     */
+    public record PlayerResult(ServerPlayer player, FunctionCallResult error) {
+        public boolean hasError() {
+            return error != null;
+        }
+    }
+
+    /**
      * 验证字符串参数类型
      *
      * @param element   Json元素

--- a/src/main/java/firefly520/fireflymc/ai/function/GetPlayerInfoFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/GetPlayerInfoFunctionTool.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject;
 import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
 import net.minecraft.core.BlockPos;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 
 /**
@@ -90,6 +91,36 @@ public class GetPlayerInfoFunctionTool implements AIFunctionTool {
         result.append(String.format("状态: %s\n", isFlying ? "飞行中" : "行走"));
         result.append(String.format("延迟: %dms", ping));
 
+        return FunctionCallResult.success(result.toString());
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        var playerResult = FunctionToolHelper.getRequiredTargetPlayer(server, arguments, "playerName");
+        if (playerResult.hasError()) return playerResult.error();
+
+        ServerPlayer targetPlayer = playerResult.player();
+        String name = targetPlayer.getGameProfile().getName();
+        BlockPos pos = targetPlayer.blockPosition();
+        String dimension = targetPlayer.serverLevel().dimension().location().toString();
+        float health = targetPlayer.getHealth();
+        float maxHealth = targetPlayer.getMaxHealth();
+        int foodLevel = targetPlayer.getFoodData().getFoodLevel();
+        int xpLevel = targetPlayer.experienceLevel;
+        float xpProgress = targetPlayer.experienceProgress;
+        String gameMode = targetPlayer.gameMode.getGameModeForPlayer().getName();
+        boolean isFlying = targetPlayer.getAbilities().flying;
+        int ping = targetPlayer.connection.latency();
+
+        StringBuilder result = new StringBuilder();
+        result.append(String.format("玩家 %s 的信息:\n", name));
+        result.append(String.format("位置: (%d, %d, %d) %s\n", pos.getX(), pos.getY(), pos.getZ(), dimension));
+        result.append(String.format("血量: %.1f/%.1f\n", health, maxHealth));
+        result.append(String.format("饥饿值: %d/20\n", foodLevel));
+        result.append(String.format("经验: 等级%d (%.1f%%)\n", xpLevel, xpProgress * 100));
+        result.append(String.format("游戏模式: %s\n", gameMode));
+        result.append(String.format("状态: %s\n", isFlying ? "飞行中" : "行走"));
+        result.append(String.format("延迟: %dms", ping));
         return FunctionCallResult.success(result.toString());
     }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/GetServerTpsFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/GetServerTpsFunctionTool.java
@@ -62,4 +62,15 @@ public class GetServerTpsFunctionTool implements AIFunctionTool {
 
         return FunctionCallResult.success(result.toString());
     }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        long tickCount = server.getTickCount();
+        StringBuilder result = new StringBuilder();
+        result.append("服务器性能信息:\n");
+        result.append(String.format("运行tick数: %d\n", tickCount));
+        result.append("注意：准确的TPS计算需要服务器支持tick时间API");
+        result.append("\n服务器运行正常（理想TPS: 20.0）");
+        return FunctionCallResult.success(result.toString());
+    }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/GetServerUptimeFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/GetServerUptimeFunctionTool.java
@@ -3,6 +3,7 @@ package firefly520.fireflymc.ai.function;
 import com.google.gson.JsonObject;
 import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 
 /**
@@ -63,6 +64,23 @@ public class GetServerUptimeFunctionTool implements AIFunctionTool {
         result.append(minutes).append("分钟 ");
         result.append(seconds).append("秒");
 
+        return FunctionCallResult.success(result.toString());
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        long tickCount = server.getTickCount();
+        long totalSeconds = tickCount / 20;
+        long days = totalSeconds / 86400;
+        long hours = (totalSeconds % 86400) / 3600;
+        long minutes = (totalSeconds % 3600) / 60;
+        long seconds = totalSeconds % 60;
+        StringBuilder result = new StringBuilder();
+        result.append("服务器已运行 ");
+        if (days > 0) result.append(days).append("天 ");
+        if (hours > 0 || days > 0) result.append(hours).append("小时 ");
+        result.append(minutes).append("分钟 ");
+        result.append(seconds).append("秒");
         return FunctionCallResult.success(result.toString());
     }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/GiveEffectFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/GiveEffectFunctionTool.java
@@ -6,6 +6,7 @@ import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.effect.MobEffectInstance;
 
@@ -153,5 +154,46 @@ public class GiveEffectFunctionTool implements AIFunctionTool {
                 String.format("已给予 %s %d级%s效果，持续%d秒",
                         targetName, amplifier + 1, effectName, duration)
         );
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        if (!arguments.has("targetPlayer")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "从控制台执行必须指定 targetPlayer");
+        }
+
+        var effectResult = FunctionToolHelper.getRequiredString(arguments, "effect");
+        if (effectResult.hasError()) return effectResult.error();
+        String effectStr = effectResult.value().toLowerCase();
+
+        int duration = FunctionToolHelper.getOptionalInt(arguments, "duration", DEFAULT_DURATION);
+        int amplifier = FunctionToolHelper.getOptionalInt(arguments, "amplifier", DEFAULT_AMPLIFIER);
+        duration = Math.max(MIN_DURATION, Math.min(MAX_DURATION, duration));
+        amplifier = Math.max(0, Math.min(MAX_AMPLIFIER, amplifier));
+
+        var targetResult = FunctionToolHelper.getRequiredTargetPlayer(server, arguments, "targetPlayer");
+        if (targetResult.hasError()) return targetResult.error();
+        String targetName = arguments.get("targetPlayer").getAsString();
+        ServerPlayer targetPlayer = targetResult.player();
+
+        ResourceLocation effectId = ResourceLocation.tryParse(effectStr);
+        if (effectId == null) {
+            effectId = ResourceLocation.tryParse("minecraft:" + effectStr);
+            if (effectId == null) {
+                return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "无效的效果ID: " + effectStr);
+            }
+        }
+
+        var effectHolder = BuiltInRegistries.MOB_EFFECT.getHolder(effectId);
+        if (effectHolder.isEmpty()) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "未知的效果: " + effectStr);
+        }
+
+        int durationTicks = duration * 20;
+        targetPlayer.addEffect(new MobEffectInstance(effectHolder.get(), durationTicks, amplifier, false, true));
+
+        String effectName = effectId.getPath().replace("_", " ");
+        return FunctionCallResult.success(
+                String.format("已给予 %s %d级%s效果，持续%d秒", targetName, amplifier + 1, effectName, duration));
     }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/GiveItemFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/GiveItemFunctionTool.java
@@ -7,6 +7,7 @@ import firefly520.fireflymc.ai.FunctionCallResult;
 import firefly520.fireflymc.ai.FunctionToolRegistry;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.Items;
@@ -168,5 +169,52 @@ public class GiveItemFunctionTool implements AIFunctionTool {
                 String.format("已给予 %s %dx %s",
                         targetName, count, itemId.toString())
         );
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        if (!arguments.has("item")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "缺少必需参数: item");
+        }
+        if (!arguments.has("targetPlayer")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "从控制台执行必须指定 targetPlayer");
+        }
+
+        String itemStr = arguments.get("item").getAsString();
+
+        int count = DEFAULT_COUNT;
+        if (arguments.has("count")) {
+            try { count = arguments.get("count").getAsInt(); }
+            catch (IllegalStateException e) {
+                return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "count参数必须是整数");
+            }
+        }
+        count = Math.max(MIN_COUNT, Math.min(MAX_COUNT, count));
+
+        var targetResult = FunctionToolHelper.getRequiredTargetPlayer(server, arguments, "targetPlayer");
+        if (targetResult.hasError()) return targetResult.error();
+
+        String targetName = arguments.get("targetPlayer").getAsString();
+        ServerPlayer targetPlayer = targetResult.player();
+
+        ResourceLocation itemId = ResourceLocation.tryParse(itemStr);
+        if (itemId == null) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "无效的物品ID: " + itemStr);
+        }
+        Item item = BuiltInRegistries.ITEM.get(itemId);
+        if (item == null || item == Items.AIR) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "未知的物品: " + itemStr);
+        }
+
+        ItemStack itemStack = new ItemStack(item, count);
+        boolean added = targetPlayer.getInventory().add(itemStack);
+
+        if (!added) {
+            targetPlayer.drop(itemStack, false);
+            return FunctionCallResult.success(
+                    String.format("已给予 %s %dx %s（背包已满，物品掉落在地上）", targetName, count, itemId.toString()));
+        }
+        return FunctionCallResult.success(
+                String.format("已给予 %s %dx %s", targetName, count, itemId.toString()));
     }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/KickPlayerFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/KickPlayerFunctionTool.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 
 /**
@@ -97,6 +98,24 @@ public class KickPlayerFunctionTool implements AIFunctionTool {
         // 踢出玩家
         targetPlayer.connection.disconnect(Component.literal(reason));
 
+        return FunctionCallResult.success("已踢出玩家 " + targetName + "，原因: " + reason);
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        var playerNameResult = FunctionToolHelper.getRequiredString(arguments, "playerName");
+        if (playerNameResult.hasError()) return playerNameResult.error();
+        String targetName = playerNameResult.value();
+
+        String reason = FunctionToolHelper.getOptionalString(arguments, "reason", DEFAULT_REASON);
+
+        ServerPlayer targetPlayer = server.getPlayerList().getPlayerByName(targetName);
+        if (targetPlayer == null) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.EXECUTION_FAILED,
+                    "玩家 " + targetName + " 不在线");
+        }
+
+        targetPlayer.connection.disconnect(Component.literal(reason));
         return FunctionCallResult.success("已踢出玩家 " + targetName + "，原因: " + reason);
     }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/ListPlayersFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/ListPlayersFunctionTool.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 
 /**
@@ -58,6 +59,42 @@ public class ListPlayersFunctionTool implements AIFunctionTool {
         int maxPlayers = server.getPlayerList().getMaxPlayers();
 
         // 获取includeDetails参数（默认false）
+        boolean includeDetails = false;
+        if (arguments.has("includeDetails") && !arguments.get("includeDetails").isJsonNull()) {
+            var elem = arguments.get("includeDetails");
+            if (elem.isJsonPrimitive() && elem.getAsJsonPrimitive().isBoolean()) {
+                includeDetails = elem.getAsBoolean();
+            }
+        }
+
+        StringBuilder result = new StringBuilder();
+        result.append(String.format("当前在线: %d/%d 人", players.size(), maxPlayers));
+
+        if (players.isEmpty()) {
+            return FunctionCallResult.success(result.toString());
+        }
+
+        result.append("\n玩家列表:");
+        for (ServerPlayer p : players) {
+            String gameMode = p.gameMode.getGameModeForPlayer().getName();
+            if (includeDetails) {
+                String dimension = p.serverLevel().dimension().location().toString();
+                result.append(String.format("\n- %s (%s, %s)",
+                        p.getGameProfile().getName(), gameMode, dimension));
+            } else {
+                result.append(String.format("\n- %s (%s)",
+                        p.getGameProfile().getName(), gameMode));
+            }
+        }
+
+        return FunctionCallResult.success(result.toString());
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        var players = server.getPlayerList().getPlayers();
+        int maxPlayers = server.getPlayerList().getMaxPlayers();
+
         boolean includeDetails = false;
         if (arguments.has("includeDetails") && !arguments.get("includeDetails").isJsonNull()) {
             var elem = arguments.get("includeDetails");

--- a/src/main/java/firefly520/fireflymc/ai/function/SetTimeFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/SetTimeFunctionTool.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 
@@ -150,6 +151,49 @@ public class SetTimeFunctionTool implements AIFunctionTool {
         }
 
         // 返回友好的时间描述
+        String timeDesc = getTimeDescription(timeValue);
+        return FunctionCallResult.success("已将时间设置为 " + timeDesc);
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        long timeValue;
+
+        if (arguments.has("time") && !arguments.get("time").isJsonNull()) {
+            FunctionCallResult validationResult = FunctionToolHelper.validateStringType(arguments.get("time"), "time");
+            if (validationResult != null) return validationResult;
+
+            String timeStr = arguments.get("time").getAsString().toLowerCase().trim();
+            if (TIME_KEYWORDS.containsKey(timeStr)) {
+                timeValue = TIME_KEYWORDS.get(timeStr);
+            } else {
+                try {
+                    timeValue = Long.parseLong(timeStr);
+                    if (timeValue < 0 || timeValue > 24000) {
+                        return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "时间值必须在0-24000之间");
+                    }
+                } catch (NumberFormatException e) {
+                    return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT,
+                            "无效的时间参数: " + timeStr + "。支持: day, night, noon, midnight, sunrise, sunset 或 0-24000的数字");
+                }
+            }
+        } else if (arguments.has("timeValue")) {
+            var timeValueElement = arguments.get("timeValue");
+            if (!timeValueElement.isJsonPrimitive() || !timeValueElement.getAsJsonPrimitive().isNumber()) {
+                return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "timeValue 参数必须是数字");
+            }
+            timeValue = timeValueElement.getAsLong();
+            if (timeValue < 0 || timeValue > 24000) {
+                return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "时间值必须在0-24000之间");
+            }
+        } else {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "缺少时间参数");
+        }
+
+        for (ServerLevel level : server.getAllLevels()) {
+            level.setDayTime(timeValue);
+        }
+
         String timeDesc = getTimeDescription(timeValue);
         return FunctionCallResult.success("已将时间设置为 " + timeDesc);
     }

--- a/src/main/java/firefly520/fireflymc/ai/function/SetWeatherFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/SetWeatherFunctionTool.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 
@@ -136,6 +137,52 @@ public class SetWeatherFunctionTool implements AIFunctionTool {
             default -> throw new IllegalStateException("无效的天气类型: " + weather);
         };
 
+        String durationDesc = duration == 0 ? "永久" : duration + "秒";
+        return FunctionCallResult.success("已将天气设置为 " + weatherDesc + "，持续 " + durationDesc);
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        if (!arguments.has("weather")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "缺少必需参数: weather");
+        }
+        var weatherElement = arguments.get("weather");
+        if (!weatherElement.isJsonPrimitive() || !weatherElement.getAsJsonPrimitive().isString()) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "weather 参数必须是字符串");
+        }
+
+        String weather = weatherElement.getAsString().toLowerCase();
+
+        int duration = DEFAULT_DURATION;
+        if (arguments.has("duration")) {
+            var durationElement = arguments.get("duration");
+            if (!durationElement.isJsonPrimitive() || !durationElement.getAsJsonPrimitive().isNumber()) {
+                return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "duration 参数必须是数字");
+            }
+            duration = durationElement.getAsInt();
+        }
+
+        duration = Math.max(MIN_DURATION, Math.min(MAX_DURATION, duration));
+        int durationTicks = duration * 20;
+
+        for (ServerLevel level : server.getAllLevels()) {
+            switch (weather) {
+                case "clear" -> level.setWeatherParameters(durationTicks, 0, false, false);
+                case "rain" -> level.setWeatherParameters(0, durationTicks, true, false);
+                case "thunder" -> level.setWeatherParameters(0, durationTicks, true, true);
+                default -> {
+                    return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT,
+                            "无效的天气类型: " + weather + "。支持: clear, rain, thunder");
+                }
+            }
+        }
+
+        String weatherDesc = switch (weather) {
+            case "clear" -> "晴天";
+            case "rain" -> "雨天";
+            case "thunder" -> "雷暴";
+            default -> throw new IllegalStateException("无效的天气类型: " + weather);
+        };
         String durationDesc = duration == 0 ? "永久" : duration + "秒";
         return FunctionCallResult.success("已将天气设置为 " + weatherDesc + "，持续 " + durationDesc);
     }

--- a/src/main/java/firefly520/fireflymc/ai/function/SpawnAllFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/SpawnAllFunctionTool.java
@@ -12,6 +12,7 @@ import net.minecraft.core.BlockPos;
 import net.minecraft.core.registries.BuiltInRegistries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.EntityType;
@@ -252,6 +253,96 @@ public class SpawnAllFunctionTool implements AIFunctionTool {
                     FunctionCallResult.ErrorType.EXECUTION_FAILED,
                     "未能生成任何生物，可能位置不适合"
             );
+        }
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        var allPlayers = server.getPlayerList().getPlayers();
+        if (allPlayers.isEmpty()) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.EXECUTION_FAILED, "当前没有在线玩家");
+        }
+
+        // 确定目标玩家列表（控制台不排除任何人）
+        List<ServerPlayer> targetPlayers;
+        if (arguments.has("targets") && arguments.get("targets").isJsonArray()) {
+            JsonArray targetsArray = arguments.get("targets").getAsJsonArray();
+            if (targetsArray.size() > 0) {
+                targetPlayers = new ArrayList<>();
+                for (var targetElement : targetsArray) {
+                    String targetName = targetElement.getAsString();
+                    ServerPlayer target = allPlayers.stream()
+                            .filter(p -> p.getGameProfile().getName().equalsIgnoreCase(targetName))
+                            .findFirst().orElse(null);
+                    if (target != null) targetPlayers.add(target);
+                }
+                if (targetPlayers.isEmpty()) {
+                    return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "未找到任何指定的目标玩家");
+                }
+            } else {
+                // 空数组，默认所有在线玩家（控制台不排除任何人）
+                targetPlayers = new ArrayList<>(allPlayers);
+            }
+        } else {
+            // 未提供targets，默认所有在线玩家
+            targetPlayers = new ArrayList<>(allPlayers);
+        }
+
+        if (targetPlayers.isEmpty()) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.EXECUTION_FAILED, "没有可用的目标玩家");
+        }
+
+        if (!arguments.has("entityType")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "缺少必需参数: entityType");
+        }
+
+        String entityTypeStr = arguments.get("entityType").getAsString();
+        int count = arguments.has("count") ? arguments.get("count").getAsInt() : DEFAULT_COUNT;
+        int radius = arguments.has("radius") ? arguments.get("radius").getAsInt() : DEFAULT_RADIUS;
+        count = Math.max(MIN_COUNT, Math.min(MAX_COUNT, count));
+        radius = Math.max(MIN_RADIUS, Math.min(MAX_RADIUS, radius));
+
+        ResourceLocation entityId = ResourceLocation.tryParse(entityTypeStr);
+        if (entityId == null) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "无效的生物类型: " + entityTypeStr);
+        }
+        EntityType<?> entityType = BuiltInRegistries.ENTITY_TYPE.get(entityId);
+        if (entityType == null) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "未知的生物类型: " + entityTypeStr);
+        }
+
+        int totalSpawned = 0;
+        int playersProcessed = 0;
+
+        for (ServerPlayer targetPlayer : targetPlayers) {
+            ServerLevel level = targetPlayer.serverLevel();
+            BlockPos playerPos = targetPlayer.blockPosition();
+            int spawnedForPlayer = 0;
+            for (int i = 0; i < count; i++) {
+                double angle = level.random.nextDouble() * Math.PI * 2;
+                double distance = level.random.nextDouble() * radius;
+                int x = (int) Math.round(playerPos.getX() + Math.cos(angle) * distance);
+                int z = (int) Math.round(playerPos.getZ() + Math.sin(angle) * distance);
+                int y = level.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, x, z);
+                BlockPos spawnPos = new BlockPos(x, y, z);
+                var entity = entityType.spawn(level, null, null, spawnPos, MobSpawnType.COMMAND, true, false);
+                if (entity != null) {
+                    spawnedForPlayer++;
+                    totalSpawned++;
+                }
+            }
+            if (spawnedForPlayer > 0) {
+                playersProcessed++;
+                targetPlayer.sendSystemMessage(Component.literal(String.format(
+                        "§e你的附近生成了 §a%d §e只 §b%s", spawnedForPlayer, entityId.toString())));
+            }
+        }
+
+        if (totalSpawned > 0) {
+            return FunctionCallResult.success(String.format(
+                    "成功在 %d 名玩家附近生成 %d 只 %s", playersProcessed, totalSpawned, entityId.toString()));
+        } else {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.EXECUTION_FAILED, "未能生成任何生物，可能位置不适合");
         }
     }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/SummonPlayerFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/SummonPlayerFunctionTool.java
@@ -4,8 +4,10 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.levelgen.Heightmap;
 
 /**
  * 召唤玩家的函数工具
@@ -101,5 +103,34 @@ public class SummonPlayerFunctionTool implements AIFunctionTool {
                 String.format("已将 %s 召唤到你的位置 %s (%.1f, %.1f, %.1f)",
                         targetName, dimensionName, x, y, z)
         );
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        if (!arguments.has("playerName")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "缺少必需参数: playerName");
+        }
+        FunctionCallResult validationResult = FunctionToolHelper.validateStringType(
+                arguments.get("playerName"), "playerName");
+        if (validationResult != null) return validationResult;
+
+        String targetName = arguments.get("playerName").getAsString();
+        ServerPlayer targetPlayer = server.getPlayerList().getPlayerByName(targetName);
+        if (targetPlayer == null) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.EXECUTION_FAILED,
+                    "玩家 " + targetName + " 不在线");
+        }
+
+        // 从控制台执行时，使用主世界出生点作为目标位置
+        ServerLevel overworld = server.overworld();
+        var spawnPos = overworld.getSharedSpawnPos();
+        double x = spawnPos.getX() + 0.5;
+        double y = overworld.getHeight(Heightmap.Types.MOTION_BLOCKING_NO_LEAVES, spawnPos.getX(), spawnPos.getZ());
+        double z = spawnPos.getZ() + 0.5;
+
+        targetPlayer.teleportTo(overworld, x, y, z, 0, 0);
+
+        return FunctionCallResult.success(
+                String.format("已将 %s 召唤到主世界出生点 (%.1f, %.1f, %.1f)", targetName, x, y, z));
     }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/TeleportPlayerFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/TeleportPlayerFunctionTool.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerPlayer;
 
 /**
@@ -126,5 +127,46 @@ public class TeleportPlayerFunctionTool implements AIFunctionTool {
                 String.format("已将 %s 传送到 %s 的位置 %s",
                         targetName, destName, dimensionName)
         );
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        if (!arguments.has("targetPlayer")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "从控制台执行必须指定 targetPlayer");
+        }
+
+        if (!arguments.has("destinationPlayer")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "缺少必需参数: destinationPlayer");
+        }
+
+        FunctionCallResult validationResult = FunctionToolHelper.validateStringType(
+                arguments.get("destinationPlayer"), "destinationPlayer");
+        if (validationResult != null) return validationResult;
+        String destName = arguments.get("destinationPlayer").getAsString();
+
+        var targetResult = FunctionToolHelper.getRequiredTargetPlayer(server, arguments, "targetPlayer");
+        if (targetResult.hasError()) return targetResult.error();
+
+        ServerPlayer targetPlayer = targetResult.player();
+
+        ServerPlayer destPlayer = server.getPlayerList().getPlayerByName(destName);
+        if (destPlayer == null) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.EXECUTION_FAILED,
+                    "玩家 " + destName + " 不在线");
+        }
+
+        ServerLevel destLevel = destPlayer.serverLevel();
+        double x = destPlayer.getX();
+        double y = destPlayer.getY();
+        double z = destPlayer.getZ();
+        float yaw = destPlayer.getYRot();
+        float pitch = destPlayer.getXRot();
+
+        targetPlayer.teleportTo(destLevel, x, y, z, yaw, pitch);
+
+        String targetName = targetPlayer.getGameProfile().getName();
+        String dimensionName = destLevel.dimension().location().toString();
+        return FunctionCallResult.success(
+                String.format("已将 %s 传送到 %s 的位置 %s", targetName, destName, dimensionName));
     }
 }

--- a/src/main/java/firefly520/fireflymc/ai/function/TeleportPositionFunctionTool.java
+++ b/src/main/java/firefly520/fireflymc/ai/function/TeleportPositionFunctionTool.java
@@ -5,6 +5,7 @@ import com.google.gson.JsonObject;
 import firefly520.fireflymc.ai.AIFunctionTool;
 import firefly520.fireflymc.ai.FunctionCallResult;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 
@@ -179,5 +180,64 @@ public class TeleportPositionFunctionTool implements AIFunctionTool {
                 String.format("已将 %s 传送到 (%.1f, %.1f, %.1f) %s",
                         playerName, x, y, z, dimensionName)
         );
+    }
+
+    @Override
+    public FunctionCallResult execute(MinecraftServer server, JsonObject arguments) {
+        if (!arguments.has("targetPlayer")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "从控制台执行必须指定 targetPlayer");
+        }
+
+        if (!arguments.has("x") || !arguments.has("y") || !arguments.has("z")) {
+            return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "缺少必需参数: x, y, z");
+        }
+
+        FunctionCallResult validationResult;
+        validationResult = FunctionToolHelper.validateNumberType(arguments.get("x"), "x");
+        if (validationResult != null) return validationResult;
+        validationResult = FunctionToolHelper.validateNumberType(arguments.get("y"), "y");
+        if (validationResult != null) return validationResult;
+        validationResult = FunctionToolHelper.validateNumberType(arguments.get("z"), "z");
+        if (validationResult != null) return validationResult;
+
+        double x = arguments.get("x").getAsDouble();
+        double y = arguments.get("y").getAsDouble();
+        double z = arguments.get("z").getAsDouble();
+
+        var targetResult = FunctionToolHelper.getRequiredTargetPlayer(server, arguments, "targetPlayer");
+        if (targetResult.hasError()) return targetResult.error();
+
+        ServerPlayer targetPlayer = targetResult.player();
+
+        ServerLevel targetLevel = targetPlayer.serverLevel();
+        if (arguments.has("dimension") && !arguments.get("dimension").isJsonNull()) {
+            validationResult = FunctionToolHelper.validateStringType(arguments.get("dimension"), "dimension");
+            if (validationResult != null) return validationResult;
+            String dimensionStr = arguments.get("dimension").getAsString();
+            ResourceLocation dimensionId = ResourceLocation.tryParse(dimensionStr);
+            if (dimensionId == null) {
+                return FunctionCallResult.failure(FunctionCallResult.ErrorType.INVALID_ARGUMENT, "无效的维度ID: " + dimensionStr);
+            }
+            ServerLevel foundLevel = null;
+            for (ServerLevel level : server.getAllLevels()) {
+                if (level.dimension().location().equals(dimensionId)) {
+                    foundLevel = level;
+                    break;
+                }
+            }
+            if (foundLevel == null) {
+                return FunctionCallResult.failure(FunctionCallResult.ErrorType.EXECUTION_FAILED, "维度不存在: " + dimensionStr);
+            }
+            targetLevel = foundLevel;
+        }
+
+        String playerName = targetPlayer.getGameProfile().getName();
+        float yaw = targetPlayer.getYRot();
+        float pitch = targetPlayer.getXRot();
+        targetPlayer.teleportTo(targetLevel, x, y, z, yaw, pitch);
+
+        String dimensionName = targetLevel.dimension().location().toString();
+        return FunctionCallResult.success(
+                String.format("已将 %s 传送到 (%.1f, %.1f, %.1f) %s", playerName, x, y, z, dimensionName));
     }
 }


### PR DESCRIPTION
- 移除命令执行者必须为玩家的限制，允许服务器终端执行AI聊天命令
- 重构多人服务器检查逻辑，支持终端和玩家两种执行路径
- 新增终端执行路径，跳过冷却时间检查并使用固定发送者名称
- 新增终端专用的AI异步调用方法，处理工具调用和结果返回
- 扩展AIFunctionTool接口，支持服务器终端执行函数调用（4级OP权限）
- 新增终端版本的工具调用处理和结果发送方法