### PR TITLE
Add guest joining, P2P support, and update documentation for Minecraft LAN bridge

### DIFF
--- a/docs/mc-neoforge-lan-bridge-guide.md
+++ b/docs/mc-neoforge-lan-bridge-guide.md
@@ -1,0 +1,539 @@
+# Minecraft 1.21.1 / NeoForge 21.1.219 — LAN 桥接 Mod 开发指南
+
+> 整理日期: 2026-05-02 | 目标: 单人世界通过 WebSocket 中继桥接远程玩家
+
+---
+
+## 一、IntegratedServer LAN 发布
+
+### 1.1 openToLAN 调用
+
+`IntegratedServer` (Mojang mapped) 的 "对局域网开放" 方法：
+
+```java
+// net.minecraft.server.integrated.IntegratedServer
+public void openToLAN(GameType gameType, boolean allowCommands)
+```
+
+- `gameType` — `GameType.SURVIVAL` / `GameType.CREATIVE` / `GameType.ADVENTURE` / `SPECTATOR`
+- `allowCommands` — 是否允许作弊命令
+- 返回类型: `void`
+
+原版调用链 (按键触发 ESC → "对局域网开放" 按钮):
+1. `OpenToLANScreen` → 用户选择参数
+2. 调用 `Minecraft#setScreen(null)` 退出菜单
+3. 内部调用 `this.singleplayerServer.openToLAN(selectedGameType, commandsAllowed)`
+4. `IntegratedServer` 内部:
+   - 设置 `this.setGameType(gameType)` 和 `this.setCommandsAllowed(allowCommands)`
+   - 调用 `this.getConnection().startTcpServerListener(null)` — **`null` 表示绑定所有接口**
+   - 通过 `LanServerPinger` 向局域网广播自身
+
+### 1.2 获取 LAN 端口
+
+LAN 端口在 `openToLAN` 调用后由系统自动分配。获取方式:
+
+```java
+IntegratedServer server = Minecraft.getInstance().getSingleplayerServer();
+if (server != null) {
+    // 方式1: 通过 ServerConnectionListener (ChannelHandler)
+    ServerConnectionListener listener = server.getConnection();
+    // listener 内部持有 TcpServerChannel
+    // 端口存储在 listener 的 ChannelGroup 中
+
+    // 方式2: 反射/AccessTransformer 获取 (推荐)
+    // ServerConnectionListener 的字段:
+    //   private final List<Channel> channels = Collections.synchronizedList(Lists.newArrayList());
+    //   Channel 的 localAddress() 就是绑定的端口
+
+    // 方式3: 使用 AT (AccessTransformer) 暴露字段
+    // 见下方字段映射
+}
+```
+
+**关键类映射:**
+
+| Obfuscated (SRG) | Mojang Mapped | 说明 |
+|---|---|---|
+| `net.minecraft.server.network.ServerConnectionListener` | 同左 | 管理 TCP 连接 |
+| `ServerConnectionListener#channels` (field) | `channels` | `List<Channel>` 已建立的连接 |
+| `ServerConnectionListener#startTcpServerListener` | 同左 | 启动 TCP 监听, 签名 `(InetAddress)` |
+| 底层 Channel 的 `localAddress()` | — | 返回 `SocketAddress`, 可取端口 |
+
+**AT 声明示例 (accesstransformer.cfg):**
+```cfg
+public-f net.minecraft.server.network.ServerConnectionListener channels # channels
+public net.minecraft.server.network.ServerConnectionListener startTcpServerListener(Ljava/net/InetAddress;)V # startTcpServerListener
+```
+
+### 1.3 代码中调用 openToLAN
+
+```java
+// 必须在渲染/主线程执行
+Minecraft mc = Minecraft.getInstance();
+IntegratedServer server = mc.getSingleplayerServer();
+if (server != null && !server.isPublished()) {
+    server.openToLAN(GameType.SURVIVAL, true);
+    server.setPublished(true);  // 标记为已发布
+
+    // 获取端口
+    ServerConnectionListener connection = server.getConnection();
+    // 需要通过 AT 或反射读取 connection 的 channels 列表
+    // 新绑定的 listener channel 的 localAddress 包含端口号
+}
+```
+
+---
+
+## 二、NeoForge 客户端生命周期事件
+
+### 2.1 进入世界相关事件
+
+| 事件 | Bus | 说明 |
+|---|---|---|
+| `ClientPlayerNetworkEvent.LoggingIn` | Game (NeoForge) | 客户端登录到服务器/集成服务器 (含单人) |
+| `ClientPlayerNetworkEvent.LoggedIn` | Game (NeoForge) | 登录完成, player 对象可用 |
+| `PlayerEvent.PlayerLoggedInEvent` | Game (NeoForge) | 服务器端也触发; 客户端收到时表示进入世界 |
+| `ClientTickEvent.Post` | Game (NeoForge) | 每帧客户端 tick, 可用于检测状态变化 |
+
+**注意:** `PlayerLoggedInEvent` 在逻辑上分为服务端和客户端触发。在集成服务器模式下, 两端都在同一进程:
+- **客户端逻辑** → 监听 `ClientPlayerNetworkEvent.LoggedIn`
+- **服务端逻辑** → 监听 `PlayerEvent.PlayerLoggedInEvent`
+
+### 2.2 退出世界 / 返回标题界面事件
+
+| 事件 | Bus | 说明 |
+|---|---|---|
+| `ClientPlayerNetworkEvent.LoggingOut` | Game (NeoForge) | 客户端开始登出, player/connection 可能已为 null |
+| `ClientPlayerNetworkEvent.LoggedOut` | Game (NeoForge) | 客户端完全登出, 回到标题画面 |
+| `PlayerEvent.PlayerLoggedOutEvent` | Game (NeoForge) | 服务端触发, 玩家断开 |
+| `ScreenEvent.Opening` | Game (NeoForge) | 屏幕即将打开 (可拦截) |
+| `ScreenEvent.Opened` | Game (NeoForge) | 屏幕已打开 |
+| `ScreenEvent.Closing` | Game (NeoForge) | 屏幕即将关闭 |
+
+**`LoggingOut` 特殊行为:**
+- 创建新的集成服务器(单人世界)或连接新服务器时也会触发
+- 构造参数: `(@Nullable MultiPlayerGameMode controller, @Nullable LocalPlayer player, @Nullable Connection networkManager)`
+- 当返回标题界面时, player 和 controller 可能为 null
+
+### 2.3 Client-Only 注册方式
+
+推荐使用 `@EventBusSubscriber` 注解:
+
+```java
+@EventBusSubscriber(modid = MOD_ID, value = Dist.CLIENT)
+public class ClientEvents {
+
+    @SubscribeEvent
+    public static void onClientTick(ClientTickEvent.Post event) {
+        // 客户端 tick 逻辑
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedIn(ClientPlayerNetworkEvent.LoggedIn event) {
+        // 客户端登录完成
+    }
+
+    @SubscribeEvent
+    public static void onPlayerLoggedOut(ClientPlayerNetworkEvent.LoggedOut event) {
+        // 客户端登出, 清理资源
+    }
+
+    @SubscribeEvent
+    public static void onScreenInit(ScreenEvent.Init.Post event) {
+        if (event.getScreen() instanceof JoinMultiplayerScreen screen) {
+            // 在多人列表界面初始化时注入自定义按钮等
+        }
+    }
+}
+```
+
+**替代方式 — 手动注册 (Mod 构造函数中):**
+
+```java
+public MyMod(IEventBus modBus) {
+    NeoForge.EVENT_BUS.addListener(ClientEvents::onClientTick);
+    NeoForge.EVENT_BUS.addListener(ClientEvents::onPlayerLoggedIn);
+    // ...
+}
+```
+
+---
+
+## 三、原版多人游戏服务器列表 UI
+
+### 3.1 关键类名 (1.21.1 Mojang 映射)
+
+| 类名 | 包路径 | 说明 |
+|---|---|---|
+| `JoinMultiplayerScreen` | `net.minecraft.client.gui.screens.multiplayer` | 多人游戏服务器列表主界面 |
+| `ServerSelectionList` | `net.minecraft.client.gui.screens.multiplayer` | 服务器列表控件 (ObjectSelectionList) |
+| `ServerData` | `net.minecraft.client.multiplayer` | 单个服务器条目数据模型 |
+| `ServerList` | `net.minecraft.client.multiplayer` | 服务器列表持久化存储 (读写 servers.dat) |
+| `ConnectScreen` | `net.minecraft.client.gui.screens.multiplayer` | 连接服务器的过渡画面 |
+
+### 3.2 ServerData 关键字段
+
+```java
+public class ServerData {
+    public String name;           // 服务器显示名称
+    public String ip;             // 地址:端口
+    public ServerData.ServerResourceMode resourceMode;  // 资源包模式
+    public boolean hidden;        // 是否在列表中隐藏
+    public String icon;           // Base64 编码的服务器图标 (64x64 PNG)
+    public ServerData.Type type;  // NORMAL / LAN / REALM
+
+    public enum Type {
+        NORMAL,    // 正常服务器
+        LAN,       // LAN 发现的服务器
+        REALM      // Realm
+    }
+}
+```
+
+### 3.3 ServerList 关键方法
+
+```java
+public class ServerList {
+    public ServerData get(int index);           // 按索引获取
+    public ServerData get(String ip);           // 按地址获取
+    public void add(ServerData data);           // 添加服务器
+    public void remove(ServerData data);        // 移除服务器
+    public void replace(int index, ServerData data);  // 替换
+    public void load();                         // 从 servers.dat 加载
+    public void save();                         // 保存到 servers.dat
+    // ...
+}
+```
+
+### 3.4 扩展多人列表 — NeoForge 事件 vs Mixin
+
+**NeoForge 事件方式 (推荐首选):**
+
+`ScreenEvent.Init.Post` 可以在 `JoinMultiplayerScreen` 初始化完成后注入自定义元素:
+```java
+@SubscribeEvent
+public static void onScreenInit(ScreenEvent.Init.Post event) {
+    if (event.getScreen() instanceof JoinMultiplayerScreen screen) {
+        // 可以在这里:
+        // 1. 在屏幕上添加自定义按钮 (event.getScreen().addRenderableWidget(...))
+        // 2. 访问 screen 的服务器列表字段
+    }
+}
+```
+
+**Mixin 注入点 (更底层的控制):**
+
+当需要修改 `ServerSelectionList` 的渲染/点击行为时, 需要 Mixin:
+
+```java
+// 注入 ServerSelectionList 的行渲染
+@Mixin(ServerSelectionList.class)
+public abstract class MixinServerSelectionList extends ObjectSelectionList<ServerSelectionList.Entry> {
+
+    // 注入点1: 在列表中添加自定义行
+    @Inject(method = "getRowWidth", at = @At("RETURN"), cancellable = true)
+    private void onGetRowWidth(CallbackInfoReturnable<Integer> cir) { }
+
+    // 注入点2: 覆盖列表行数
+    @Inject(method = "getItemCount", at = @At("RETURN"), cancellable = true)
+    private void onGetItemCount(CallbackInfoReturnable<Integer> cir) { }
+
+    // 注入点3: 自定义行的渲染和点击
+    @Inject(method = "renderList", at = @At("TAIL"))
+    private void onRenderList(DrawContext context, int mouseX, int mouseY, float partialTick, CallbackInfo ci) { }
+}
+```
+
+```java
+// 注入 JoinMultiplayerScreen 的连接流程
+@Mixin(JoinMultiplayerScreen.class)
+public class MixinJoinMultiplayerScreen {
+
+    // 拦截 "加入服务器" 按钮点击
+    @Inject(method = "joinSelectedServer", at = @At("HEAD"), cancellable = true)
+    private void onJoinSelected(CallbackInfo ci) {
+        // 可以自定义连接逻辑或拦截
+    }
+}
+```
+
+---
+
+## 四、客户端连接服务器流程
+
+### 4.1 原版连接流程
+
+```
+用户点击 "加入服务器"
+    → JoinMultiplayerScreen.joinSelectedServer()
+        → ServerData 验证地址格式
+        → ConnectScreen.startConnecting(parentScreen, minecraft, ServerAddress, ServerData)
+            → 创建 ClientHandshakePacketListener / ClientIntentionPacket
+            → 建立 TCP 连接到目标地址
+            → 完成握手 → 配置阶段 → 登录阶段 → 游戏阶段
+```
+
+### 4.2 代码触发连接
+
+```java
+// 方式1: 通过 ConnectScreen (推荐, 有完整的 UI 和错误处理)
+ServerAddress address = ServerAddress.parse("127.0.0.1:25565");
+ServerData serverData = new ServerData("LAN Bridge", "127.0.0.1:25565", ServerData.Type.NORMAL);
+
+ConnectScreen.startConnecting(
+    Minecraft.getInstance().screen,  // 当前屏幕 (作为父屏幕)
+    Minecraft.getInstance(),          // Minecraft 实例
+    address,                         // 服务器地址
+    serverData                       // 服务器数据 (可为 null)
+);
+```
+
+```java
+// 方式2: 直接操作 (无 UI 过渡, 适合静默连接)
+Minecraft mc = Minecraft.getInstance();
+ServerAddress address = ServerAddress.parse("127.0.0.1:" + lanPort);
+
+// ConnectScreen.startConnecting 内部会创建 Connection 并发起握手
+// 需要确保在渲染线程调用
+mc.execute(() -> {
+    ConnectScreen.startConnecting(
+        mc.screen,
+        mc,
+        address,
+        null  // ServerData 可为 null
+    );
+});
+```
+
+### 4.3 连接本地 127.0.0.1:<port>
+
+**安全:** 完全可行。集成服务器默认绑定 `0.0.0.0:<随机端口>`, 本机 `127.0.0.1` 连接不会经过外部网络。
+
+**注意事项:**
+- 如果玩家本机已经在这个集成服务器里 (单人世界的主人), **不能第二次连接** — 一个 Minecraft 实例只能有一个活动连接
+- 这个连接场景是给 **远程玩家通过 WebSocket 中继连接到本机 LAN 端口** 使用的
+- 远程客户端 (运行你 Mod 的另一个 Minecraft 实例) 可以通过 `ConnectScreen.startConnecting` 连接到 `127.0.0.1:<中继本地端口>` — 这里需要一个 WebSocket→TCP 的桥接
+
+---
+
+## 五、WebSocket 二进制帧中继设计
+
+### 5.1 Java 21 `java.net.http.WebSocket` 实践
+
+```java
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.util.concurrent.CompletionStage;
+
+public class McPacketRelay {
+
+    private WebSocket ws;
+    private final ByteBuffer accumulator = ByteBuffer.allocate(1 << 20); // 1MB
+
+    public void connect(String serverUrl) {
+        HttpClient client = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .build();
+
+        ws = client.newWebSocketBuilder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .buildAsync(URI.create(serverUrl), new WebSocketListener())
+            .join();
+    }
+
+    private class WebSocketListener implements WebSocket.Listener {
+
+        // --- 二进制帧接收 ---
+        // 注意: 大消息会被分片 (last=false), 需要手动累积
+        @Override
+        public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+            // 将分片数据写入 accumulator
+            accumulator.put(data);
+            if (last) {
+                accumulator.flip();
+                byte[] fullPacket = new byte[accumulator.remaining()];
+                accumulator.get(fullPacket);
+                accumulator.clear();
+
+                // 完整的 Minecraft 数据包 — 转发到本地 LAN 端口
+                forwardToLocalServer(fullPacket);
+            }
+            // 返回 null 表示可以继续接收
+            // 如果需要背压控制, 返回未完成的 CompletableFuture 来暂停接收
+            return null;
+        }
+
+        // --- 心跳 (Ping) ---
+        @Override
+        public CompletionStage<?> onPing(WebSocket webSocket, ByteBuffer message) {
+            // 自动回复 Pong (JDK WebSocket 默认行为)
+            // 无需手动处理, 除非需要自定义
+            return webSocket.sendPong(message);
+        }
+
+        @Override
+        public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+            System.out.println("WebSocket closed: " + statusCode + " " + reason);
+            return null;
+        }
+
+        @Override
+        public void onError(WebSocket webSocket, Throwable error) {
+            error.printStackTrace();
+        }
+    }
+
+    // --- 发送二进制数据 ---
+    public void sendPacket(byte[] packet) {
+        if (ws != null && !ws.isInputClosed() && !ws.isOutputClosed()) {
+            // 对于大的 Minecraft 数据包 (>125 bytes), JDK 会自动分片
+            // 默认分片大小等于发送缓冲区大小
+            ws.sendBinary(ByteBuffer.wrap(packet), true);
+        }
+    }
+
+    // --- 背压控制 ---
+    // 方式1: 使用 request(n) 控制接收速率
+    // 初始 request(1), 处理完后再次 request(1)
+    // 方式2: 在 onBinary 中返回未完成的 CompletableFuture
+    //   当本地 TCP 发送缓冲区满时, 返回 pending 的 Future
+    //   处理完成后再 complete 该 Future
+
+    // --- 断线重连 ---
+    public void reconnect() {
+        connect("wss://fk.firefly520.top/relay");
+    }
+}
+```
+
+### 5.2 分片与背压要点
+
+**分片 (Fragmentation):**
+- WebSocket 协议允许消息被分成多个帧
+- `onBinary` 的 `last` 参数指示是否为最后一帧
+- JDK `WebSocket.sendBinary(buffer, last)` — 设置 `last=true` 标记消息结束
+- Minecraft 数据包通常 < 2MB, 一般不需要发送端分片
+- 但接收端必须处理 `last=false` 的分片情况 (某些代理/中间件可能分片)
+
+**背压 (Backpressure):**
+- `WebSocket.Listener` 通过 `request(long n)` 控制接收速率
+- JDK 默认在创建时 `request(1)`, 每次 receive 方法返回的 `CompletionStage` 完成后再 `request(1)`
+- **隐式背压:** 从 `onBinary` 返回未完成的 `CompletionStage` 会暂停后续消息的接收
+- **实践建议:**
+  ```
+  接收 → 累积分片 → 完整包 → 写入本地 TCP
+                                    ↓
+                          如果 TCP 缓冲区满 → 阻塞 → 返回未完成 Future (暂停 WS 接收)
+                          如果 TCP 缓冲区有空 → 立即返回 null (继续接收)
+  ```
+
+### 5.3 wss://fk.firefly520.top/ 服务支持情况
+
+> 需要确认该服务器是否支持以下功能:
+> - 二进制帧 (Binary frames) — WebSocket 协议标准特性, 大多数服务端支持
+> - 房间列表 / 房间管理 — 取决于服务端实现
+> - 心跳保活 — WebSocket 协议内置 Ping/Pong, 服务端是否主动发送取决于配置
+
+**建议:** 在 Mod 端实现自己的房间发现和心跳机制, 不依赖服务端特定功能。Mod 连接后发送注册消息, 服务端维护房间映射表。
+
+---
+
+## 六、中继架构总览
+
+```
+房主 (Host)                          远程玩家 (Guest)
+┌──────────────┐                    ┌──────────────┐
+│ MC 客户端     │                    │ MC 客户端     │
+│ (NeoForge)   │                    │ (NeoForge)   │
+│              │                    │              │
+│ Mod:         │                    │ Mod:         │
+│ - openToLAN  │                    │ - WS Client  │
+│ - 获取端口   │                    │ - WS→TCP桥   │
+│ - WS Client  │                    │ - 127.0.0.1  │
+│ - TCP→WS桥   │                    │   :本地端口   │
+│ - 房间注册   │                    │              │
+└──────┬───────┘                    └──────┬───────┘
+       │                                   │
+       │    wss://fk.firefly520.top/       │
+       │    ┌─────────────────────┐        │
+       └───→│ WebSocket 中继服务   │←───────┘
+            │                     │
+            │ - 房间管理          │
+            │ - 二进制帧转发      │
+            │ - 心跳检测          │
+            └─────────────────────┘
+```
+
+---
+
+## 七、安全与权限
+
+### 7.1 公开无密码房间的推荐限制
+
+| 限制项 | 建议值 | 说明 |
+|---|---|---|
+| 最大玩家数 | 8-10 | LAN 集成服务器默认 `max-players=8`, 不建议超过 10 |
+| 房间超时 | 30 分钟无活动 | 房主 AFK 或所有玩家断线后自动清理 |
+| 房主断线清理 | 立即/5秒延迟 | 房主断线后, 集成服务器会关闭, 房间应立即标记失效 |
+| 限流 | 每连接 64KB/s | Minecraft 游戏数据通常远小于此 |
+| 单 IP 连接数 | 1 | 防止单个 IP 占满房间 |
+| 心跳间隔 | 15-30 秒 | WebSocket Ping/Pong 或应用层心跳 |
+| 数据包大小上限 | 2MB (2097152 bytes) | Minecraft 单包上限, 超过此值的包是异常的 |
+| 连接速率限制 | 同 IP 3次/10秒 | 防止暴力连接 |
+| 房间 TTL | 最长 24 小时 | 防止僵尸房间 |
+
+### 7.2 房主断线清理流程
+
+```
+房主 WS 连接断开
+    → 心跳超时 / onClose 触发
+    → 中继服务检测到房主离线
+    → 通知所有远程玩家 ("房主已断线, 房间关闭")
+    → 关闭所有该房间的 WS 连接
+    → 从房间列表中移除
+    → 清理相关资源
+
+// 远程玩家端
+WebSocket onClose → 收到 1001 (Going Away) 或自定义关闭码
+    → 显示断线消息
+    → 断开本地 TCP 连接 (如果还在连接中)
+    → 返回多人服务器列表界面
+```
+
+### 7.3 额外安全建议
+
+- **不要暴露房主的公网 IP** — 中继服务应只转发数据, 不泄露 IP
+- **房间 ID 使用随机 UUID** — 不可预测, 防止房间枚举
+- **速率限制中继层** — 防止滥用 WebSocket 连接
+- **数据包校验** — 验证包长度在合理范围内, 丢弃异常包
+- **OP 权限隔离** — 远程玩家应被限制为普通玩家, 即使房主开启了 allowCommands
+
+---
+
+## 八、关键类引用 (Javadoc)
+
+| 类 | 用途 | Javadoc |
+|---|---|---|
+| `IntegratedServer` | 集成服务器, openToLAN | [nekoyue/ForgeJavaDocs](https://nekoyue.github.io/ForgeJavaDocs-NG/javadoc/1.21.x-neoforge/) |
+| `ServerConnectionListener` | TCP 连接管理 | 同上 |
+| `ConnectScreen` | 连接服务器 | [Fabric Yarn](https://maven.fabricmc.net/docs/yarn-1.21.11+build.1/) |
+| `JoinMultiplayerScreen` | 多人列表界面 | 同上 |
+| `ServerSelectionList` | 服务器列表控件 | 同上 |
+| `ServerData` | 服务器条目数据 | [aldak Javadoc](https://aldak.netlify.app/javadoc/1.21.8-21.8.x/) |
+| `ServerList` | 服务器列表持久化 | 同上 |
+| `ClientPlayerNetworkEvent` | 客户端网络事件 | 同上 |
+| `java.net.http.WebSocket` | JDK WebSocket 客户端 | [Oracle JDK 21](https://docs.oracle.com/en/java/javase/21/docs/api/java.net.http/java/net/http/WebSocket.html) |
+
+---
+
+## 九、参考 Mod 项目
+
+| 项目 | 说明 |
+|---|---|
+| [LanServerProperties](https://github.com/rikka0w0/LanServerProperties) | 增强原版 LAN 界面, 自定义端口/关闭认证。支持 NeoForge, client-only, 含 Mixin 注入 `openToLAN` 的参考实现 |
+| [LAN World Plug-n-Play](https://www.curseforge.com/minecraft/mc-mods/mcwifipnp) | 自动将 LAN 世界发布到公共服务器, 供远程玩家发现和加入 |
+| [Custom LAN](https://modrinth.com/mod/custom-lan) | 更多 Open to LAN 自定义选项 |
+
+LanServerProperties 的 `1.21` 分支是参考 `openToLAN` 调用方式、端口获取和 Mixin 注入点的最佳实践。

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ mod_name=FireflyMC
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=All Rights Reserved
 # The mod version. See https://semver.org/
-mod_version=2.4.1
+mod_version=2.5.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/firefly520/fireflymc/Config.java
+++ b/src/main/java/firefly520/fireflymc/Config.java
@@ -16,6 +16,11 @@ public class Config {
 
   public static class ClientConfig {
     public final ModConfigSpec.DoubleValue HUD_SCALE;
+    public final ModConfigSpec.BooleanValue SINGLEPLAYER_RELAY_ENABLED;
+    public final ModConfigSpec.BooleanValue SINGLEPLAYER_RELAY_PROMPT_ON_JOIN;
+    public final ModConfigSpec.BooleanValue SINGLEPLAYER_RELAY_ALLOW_COMMANDS;
+    public final ModConfigSpec.IntValue SINGLEPLAYER_RELAY_MAX_PLAYERS;
+    public final ModConfigSpec.ConfigValue<String> SINGLEPLAYER_RELAY_URL;
 
     public ClientConfig(ModConfigSpec.Builder builder) {
       // 给配置节指定翻译键，官方推荐格式：<modid>.config.<节名>
@@ -29,6 +34,36 @@ public class Config {
               .defineInRange("hud_scale", 0.5, 0.5, 1.0);
 
       // 退出配置节
+      builder.pop();
+
+      builder.push("singleplayer_relay")
+        .translation("fireflymc.config.singleplayer_relay");
+
+      SINGLEPLAYER_RELAY_ENABLED = builder
+        .comment("Enable the singleplayer public lobby prompt and LAN bridge preparation")
+        .translation("fireflymc.config.singleplayer_relay.enabled")
+        .define("enabled", true);
+
+      SINGLEPLAYER_RELAY_PROMPT_ON_JOIN = builder
+        .comment("Show a prompt after entering a singleplayer world to ask whether to publish it")
+        .translation("fireflymc.config.singleplayer_relay.prompt_on_join")
+        .define("promptOnJoin", true);
+
+      SINGLEPLAYER_RELAY_ALLOW_COMMANDS = builder
+        .comment("Allow commands when opening the integrated server to LAN for relay hosting")
+        .translation("fireflymc.config.singleplayer_relay.allow_commands")
+        .define("allowCommands", false);
+
+      SINGLEPLAYER_RELAY_MAX_PLAYERS = builder
+        .comment("Maximum remote players allowed by the future relay lobby")
+        .translation("fireflymc.config.singleplayer_relay.max_players")
+        .defineInRange("maxPlayers", 8, 1, 10);
+
+      SINGLEPLAYER_RELAY_URL = builder
+        .comment("WebSocket URL for FireflyMC singleplayer relay lobby")
+        .translation("fireflymc.config.singleplayer_relay.relay_url")
+        .define("relayUrl", "wss://fk.firefly520.top/relay");
+
       builder.pop();
     }
   }

--- a/src/main/java/firefly520/fireflymc/Config.java
+++ b/src/main/java/firefly520/fireflymc/Config.java
@@ -21,6 +21,12 @@ public class Config {
     public final ModConfigSpec.BooleanValue SINGLEPLAYER_RELAY_ALLOW_COMMANDS;
     public final ModConfigSpec.IntValue SINGLEPLAYER_RELAY_MAX_PLAYERS;
     public final ModConfigSpec.ConfigValue<String> SINGLEPLAYER_RELAY_URL;
+    public final ModConfigSpec.BooleanValue SINGLEPLAYER_RELAY_P2P_ENABLED;
+    public final ModConfigSpec.IntValue SINGLEPLAYER_RELAY_P2P_CONNECT_TIMEOUT_SECONDS;
+    public final ModConfigSpec.IntValue SINGLEPLAYER_RELAY_P2P_UDP_PORT_MIN;
+    public final ModConfigSpec.IntValue SINGLEPLAYER_RELAY_P2P_UDP_PORT_MAX;
+    public final ModConfigSpec.IntValue SINGLEPLAYER_RELAY_P2P_RETRANSMIT_MILLIS;
+    public final ModConfigSpec.IntValue SINGLEPLAYER_RELAY_P2P_WINDOW_SIZE;
 
     public ClientConfig(ModConfigSpec.Builder builder) {
       // 给配置节指定翻译键，官方推荐格式：<modid>.config.<节名>
@@ -63,6 +69,36 @@ public class Config {
         .comment("WebSocket URL for FireflyMC singleplayer relay lobby")
         .translation("fireflymc.config.singleplayer_relay.relay_url")
         .define("relayUrl", "wss://fk.firefly520.top/relay");
+
+      SINGLEPLAYER_RELAY_P2P_ENABLED = builder
+        .comment("Try P2P UDP tunnel before falling back to the WebSocket relay")
+        .translation("fireflymc.config.singleplayer_relay.p2p_enabled")
+        .define("p2pEnabled", true);
+
+      SINGLEPLAYER_RELAY_P2P_CONNECT_TIMEOUT_SECONDS = builder
+        .comment("P2P connection timeout before falling back to relay")
+        .translation("fireflymc.config.singleplayer_relay.p2p_connect_timeout_seconds")
+        .defineInRange("p2pConnectTimeoutSeconds", 10, 3, 30);
+
+      SINGLEPLAYER_RELAY_P2P_UDP_PORT_MIN = builder
+        .comment("Minimum local UDP port for P2P endpoints, 0 means random port")
+        .translation("fireflymc.config.singleplayer_relay.p2p_udp_port_min")
+        .defineInRange("p2pUdpPortMin", 0, 0, 65535);
+
+      SINGLEPLAYER_RELAY_P2P_UDP_PORT_MAX = builder
+        .comment("Maximum local UDP port for P2P endpoints, 0 means random port")
+        .translation("fireflymc.config.singleplayer_relay.p2p_udp_port_max")
+        .defineInRange("p2pUdpPortMax", 0, 0, 65535);
+
+      SINGLEPLAYER_RELAY_P2P_RETRANSMIT_MILLIS = builder
+        .comment("Reliable UDP retransmission interval in milliseconds")
+        .translation("fireflymc.config.singleplayer_relay.p2p_retransmit_millis")
+        .defineInRange("p2pRetransmitMillis", 120, 50, 1000);
+
+      SINGLEPLAYER_RELAY_P2P_WINDOW_SIZE = builder
+        .comment("Reliable UDP sliding window size in packets")
+        .translation("fireflymc.config.singleplayer_relay.p2p_window_size")
+        .defineInRange("p2pWindowSize", 64, 8, 512);
 
       builder.pop();
     }

--- a/src/main/java/firefly520/fireflymc/FireflyMCMod.java
+++ b/src/main/java/firefly520/fireflymc/FireflyMCMod.java
@@ -49,7 +49,7 @@ public class FireflyMCMod {
       NeoForge.EVENT_BUS.addListener(ClientHandler::onRenderGui);
       // 注册主菜单更新通知检测器
       NeoForge.EVENT_BUS.addListener(TitleScreenDetector::onScreenRender);
-      // 注册单人世界联机阶段一事件
+      // 注册单人世界公开联机事件
       NeoForge.EVENT_BUS.addListener(SingleplayerRelayClientEvents::onClientLoggedIn);
       NeoForge.EVENT_BUS.addListener(SingleplayerRelayClientEvents::onClientLoggedOut);
       NeoForge.EVENT_BUS.addListener(SingleplayerRelayClientEvents::onClientTick);

--- a/src/main/java/firefly520/fireflymc/FireflyMCMod.java
+++ b/src/main/java/firefly520/fireflymc/FireflyMCMod.java
@@ -24,7 +24,7 @@ import firefly520.fireflymc.util.ServerLanguageLoader;
 @Mod(FireflyMCMod.MODID)
 public class FireflyMCMod {
   public static final String MODID = "fireflymc";
-  public static final String VERSION = "2.4.1";
+  public static final String VERSION = "2.5.0";
 
   public FireflyMCMod(IEventBus modEventBus, ModContainer modContainer) {
     // 1. 注册客户端配置（官方标准写法）
@@ -72,7 +72,7 @@ public class FireflyMCMod {
     // 5. 检查Mod更新
     UpdateChecker.checkForUpdate();
 
-    System.out.println("Loading FireflyMC 2.4.1");
+    System.out.println("Loading FireflyMC 2.5.0");
   }
 
   // 配置热重载时更新缓存

--- a/src/main/java/firefly520/fireflymc/FireflyMCMod.java
+++ b/src/main/java/firefly520/fireflymc/FireflyMCMod.java
@@ -82,17 +82,14 @@ public class FireflyMCMod {
 
   // 服务端启动完成后加载中文语言文件
   private void onServerStarted(ServerStartedEvent event) {
-    if (event.getServer().isSingleplayer()) {
-      return;
-    }
-
     ServerLanguageLoader.loadZhCnLanguage();
     // 设置服务器实例，用于WebSocket接收消息后广播
     firefly520.fireflymc.event.websocket.PlayerEventWebSocketClient.setServer(event.getServer());
-    // 启动掉落物自动清理
-    ItemCleanupManager.getInstance().start(event.getServer());
-    // 启动在线时长限制
-    PlaytimeManager.getInstance().start(event.getServer());
+    // 服务端型限制仅在专用多人服务器启用，单人/集成服/LAN大厅不启用
+    if (event.getServer().isDedicatedServer()) {
+      ItemCleanupManager.getInstance().start(event.getServer());
+      PlaytimeManager.getInstance().start(event.getServer());
+    }
   }
 
   // 服务端关闭时清理资源
@@ -106,9 +103,11 @@ public class FireflyMCMod {
     firefly520.fireflymc.event.websocket.PlayerEventWebSocketClient.clearServer();
     // 关闭成员验证管理器
     firefly520.fireflymc.event.websocket.MemberVerificationManager.getInstance().shutdown();
-    // 停止在线时长限制
-    PlaytimeManager.getInstance().stop();
-    // 停止掉落物自动清理
-    ItemCleanupManager.getInstance().stop();
+    if (event.getServer().isDedicatedServer()) {
+      // 停止在线时长限制
+      PlaytimeManager.getInstance().stop();
+      // 停止掉落物自动清理
+      ItemCleanupManager.getInstance().stop();
+    }
   }
 }

--- a/src/main/java/firefly520/fireflymc/FireflyMCMod.java
+++ b/src/main/java/firefly520/fireflymc/FireflyMCMod.java
@@ -15,6 +15,7 @@ import net.neoforged.neoforge.event.server.ServerStoppingEvent;
 import firefly520.fireflymc.client.ClientHandler;
 import firefly520.fireflymc.client.UpdateChecker;
 import firefly520.fireflymc.client.TitleScreenDetector;
+import firefly520.fireflymc.client.relay.SingleplayerRelayClientEvents;
 import firefly520.fireflymc.event.websocket.PlayerEventWebSocketClient;
 import firefly520.fireflymc.network.ModNetwork;
 import firefly520.fireflymc.playtime.PlaytimeManager;
@@ -48,6 +49,11 @@ public class FireflyMCMod {
       NeoForge.EVENT_BUS.addListener(ClientHandler::onRenderGui);
       // 注册主菜单更新通知检测器
       NeoForge.EVENT_BUS.addListener(TitleScreenDetector::onScreenRender);
+      // 注册单人世界联机阶段一事件
+      NeoForge.EVENT_BUS.addListener(SingleplayerRelayClientEvents::onClientLoggedIn);
+      NeoForge.EVENT_BUS.addListener(SingleplayerRelayClientEvents::onClientLoggedOut);
+      NeoForge.EVENT_BUS.addListener(SingleplayerRelayClientEvents::onClientTick);
+      NeoForge.EVENT_BUS.addListener(SingleplayerRelayClientEvents::onScreenInit);
     }
 
     // 4. 注册游戏事件处理（GAME 总线）
@@ -76,6 +82,10 @@ public class FireflyMCMod {
 
   // 服务端启动完成后加载中文语言文件
   private void onServerStarted(ServerStartedEvent event) {
+    if (event.getServer().isSingleplayer()) {
+      return;
+    }
+
     ServerLanguageLoader.loadZhCnLanguage();
     // 设置服务器实例，用于WebSocket接收消息后广播
     firefly520.fireflymc.event.websocket.PlayerEventWebSocketClient.setServer(event.getServer());
@@ -87,6 +97,10 @@ public class FireflyMCMod {
 
   // 服务端关闭时清理资源
   private void onServerStopping(ServerStoppingEvent event) {
+    if (event.getServer().isSingleplayer()) {
+      return;
+    }
+
     ServerLanguageLoader.clear();
     // 清理WebSocket服务器实例引用
     firefly520.fireflymc.event.websocket.PlayerEventWebSocketClient.clearServer();

--- a/src/main/java/firefly520/fireflymc/ModEventHandler.java
+++ b/src/main/java/firefly520/fireflymc/ModEventHandler.java
@@ -50,7 +50,11 @@ public class ModEventHandler {
             UUID playerUuid = serverPlayer.getUUID();
             MinecraftServer server = serverPlayer.server;
 
-            // 检查成员验证状态
+            if (server.isSingleplayer()) {
+                return;
+            }
+
+            // 检查成员验证状态（仅多人/专用服务器需要；单人世界的集成服务器不走验证服务器流程）
             if (WebSocketConfig.ENABLE_MEMBER_VERIFICATION &&
                 ServerConfig.SERVER.enableMemberVerification.get()) {
                 MemberVerificationManager.getInstance().requestVerification(serverPlayer);
@@ -113,6 +117,10 @@ public class ModEventHandler {
         if (event.getEntity() instanceof ServerPlayer serverPlayer) {
             UUID playerUuid = serverPlayer.getUUID();
             String playerId = serverPlayer.getGameProfile().getName();
+            if (serverPlayer.server.isSingleplayer()) {
+                return;
+            }
+
             ModPayloadHandler.VERIFIED_PLAYERS.remove(playerUuid);
             ModPayloadHandler.CONFIRMED_PLAYERS.remove(playerUuid);
             // 清理超时任务

--- a/src/main/java/firefly520/fireflymc/client/ClientState.java
+++ b/src/main/java/firefly520/fireflymc/client/ClientState.java
@@ -17,7 +17,7 @@ public class ClientState {
     public static boolean hasHandledSingleplayerRelayPrompt = false;
 
     /**
-     * 当前会话是否正在为单人世界联机进行 LAN 暴露准备
+     * 当前会话是否正在公开单人世界联机房间
      */
     public static boolean isSingleplayerRelayHosting = false;
 

--- a/src/main/java/firefly520/fireflymc/client/ClientState.java
+++ b/src/main/java/firefly520/fireflymc/client/ClientState.java
@@ -12,6 +12,21 @@ public class ClientState {
     public static boolean hasSeenRulesThisSession = false;
 
     /**
+     * 当前单人世界会话是否已处理过联机提示
+     */
+    public static boolean hasHandledSingleplayerRelayPrompt = false;
+
+    /**
+     * 当前会话是否正在为单人世界联机进行 LAN 暴露准备
+     */
+    public static boolean isSingleplayerRelayHosting = false;
+
+    /**
+     * 当前单人世界联机使用的 LAN 端口，-1 表示尚未获取
+     */
+    public static int singleplayerRelayLanPort = -1;
+
+    /**
      * Mod更新通知
      */
     public static boolean hasUpdateAvailable = false;

--- a/src/main/java/firefly520/fireflymc/client/HUDRenderer.java
+++ b/src/main/java/firefly520/fireflymc/client/HUDRenderer.java
@@ -43,6 +43,10 @@ public class HUDRenderer
       return;
     }
 
+    if (mc.getSingleplayerServer() != null) {
+      return;
+    }
+
     LocalPlayer player = mc.player;
     if (player == null) {
       return;

--- a/src/main/java/firefly520/fireflymc/client/HUDRenderer.java
+++ b/src/main/java/firefly520/fireflymc/client/HUDRenderer.java
@@ -43,7 +43,7 @@ public class HUDRenderer
       return;
     }
 
-    if (mc.getSingleplayerServer() != null) {
+    if (mc.getSingleplayerServer() != null && !mc.getSingleplayerServer().isPublished()) {
       return;
     }
 

--- a/src/main/java/firefly520/fireflymc/client/HUDRenderer.java
+++ b/src/main/java/firefly520/fireflymc/client/HUDRenderer.java
@@ -17,7 +17,7 @@ import firefly520.fireflymc.Config;
 
 public class HUDRenderer
 {
-  private static final Component SERVER_NAME = Component.literal("FireflyMC 2.4.1");
+  private static final Component SERVER_NAME = Component.literal("FireflyMC 2.5.0");
   private static final Component WEBSITE_URL = Component.literal("https://mc.firefly520.top");
   private static final Component PLAYER_COUNT_PREFIX = Component.literal("在线人数: ");
 

--- a/src/main/java/firefly520/fireflymc/client/HUDRenderer.java
+++ b/src/main/java/firefly520/fireflymc/client/HUDRenderer.java
@@ -53,7 +53,8 @@ public class HUDRenderer
     }
 
 
-    int playerCount = getPlayerCount(player);
+    List<String> playerNames = getOnlinePlayerNames(player);
+    int playerCount = playerNames.size();
 
 
     Font font = mc.font;
@@ -68,8 +69,9 @@ public class HUDRenderer
     // 计算网址换行后的行数
     int urlLines = font.split(WEBSITE_URL, baseWidth).size();
 
-    // 总高度 = 服务器名(1行) + 在线人数(1行) + 网址(urlLines行) + 分隔线(1行) + 玩家列表(MAX_VISIBLE_PLAYERS行)
-    int playerListHeight = lineHeight * (MAX_VISIBLE_PLAYERS + 1); // +1 for separator
+    // 总高度 = 服务器名(1行) + 在线人数(1行) + 网址(urlLines行) + 分隔线(1行) + 实际可见玩家列表行
+    int visiblePlayerCount = Math.min(playerCount, MAX_VISIBLE_PLAYERS);
+    int playerListHeight = lineHeight * (visiblePlayerCount + 1); // +1 for separator
     int totalHeight = lineHeight * (2 + urlLines) + playerListHeight + 6;
     int x = 5;
 
@@ -139,33 +141,12 @@ public class HUDRenderer
     y += lineHeight;
 
     // 渲染玩家列表
-    renderPlayerList(guiGraphics, font, x, y, baseWidth, lineHeight, player);
+    renderPlayerList(guiGraphics, font, x, y, baseWidth, lineHeight, playerNames);
 
     // 恢复缩放
     guiGraphics.pose().popPose();
   }
 
-
-
-
-
-  private static int getPlayerCount(LocalPlayer player) {
-    ClientPacketListener connection = player.connection;
-    if (connection != null) {
-
-      try {
-        if (connection.getOnlinePlayers() != null) {
-          return connection.getOnlinePlayers().size();
-        }
-      } catch (Exception e) {
-
-        return 1;
-      }
-    }
-
-
-    return 1;
-  }
 
   private static List<String> getOnlinePlayerNames(LocalPlayer player) {
     List<String> playerNames = new ArrayList<>();
@@ -204,8 +185,7 @@ public class HUDRenderer
 
   private static int renderPlayerList(GuiGraphics guiGraphics, Font font,
                                      int x, int y, int width, int lineHeight,
-                                     LocalPlayer player) {
-    List<String> playerNames = getOnlinePlayerNames(player);
+                                     List<String> playerNames) {
     int totalPlayers = playerNames.size();
 
     // 分隔线

--- a/src/main/java/firefly520/fireflymc/client/ModUpdateScreen.java
+++ b/src/main/java/firefly520/fireflymc/client/ModUpdateScreen.java
@@ -98,7 +98,7 @@ public class ModUpdateScreen extends Screen {
         // 版本信息卡片
         String versionText = ClientState.updateVersion != null ? ClientState.updateVersion : "最新版本";
         String modName = "FireflyMC 模组";
-        String currentVer = "当前版本  2.4.1";
+        String currentVer = "当前版本  2.5.0";
         String latestVer = "最新版本  " + versionText;
         String desc = "检测到新版本可用，请更新以继续游玩FireflyMC";
 

--- a/src/main/java/firefly520/fireflymc/client/RulesLoader.java
+++ b/src/main/java/firefly520/fireflymc/client/RulesLoader.java
@@ -133,7 +133,7 @@ public class RulesLoader {
                 continue;
             }
 
-            // 解析Mod更新地址: # Mod更新地址: https://mc.firefly520.top/ireflymc-2.4.1.jar
+            // 解析Mod更新地址: # Mod更新地址: https://mc.firefly520.top/ireflymc-2.5.0.jar
             if (trimmedLine.startsWith("# Mod更新地址:")) {
                 if (trimmedLine.length() > 10) {
                     modUpdateUrl = trimmedLine.substring(10).trim();

--- a/src/main/java/firefly520/fireflymc/client/UpdateChecker.java
+++ b/src/main/java/firefly520/fireflymc/client/UpdateChecker.java
@@ -40,7 +40,7 @@ public class UpdateChecker {
 
     /**
      * 从URL中提取版本号
-     * 例如: https://mc.firefly520.top/ireflymc-2.4.1.jar -> 2.4.1
+     * 例如: https://mc.firefly520.top/ireflymc-2.5.0.jar -> 2.5.0
      */
     private static String extractVersionFromUrl(String url) {
         int lastSlash = url.lastIndexOf('/');

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayControlMessage.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayControlMessage.java
@@ -1,0 +1,62 @@
+package firefly520.fireflymc.client.relay;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * Relay 通用控制响应。
+ */
+public class RelayControlMessage {
+    private static final Gson GSON = new Gson();
+
+    @SerializedName("type")
+    private String type;
+
+    @SerializedName("roomId")
+    private String roomId;
+
+    @SerializedName("guestSessionId")
+    private String guestSessionId;
+
+    @SerializedName("streamId")
+    private String streamId;
+
+    @SerializedName("code")
+    private String code;
+
+    @SerializedName("message")
+    private String message;
+
+    public static RelayControlMessage fromJson(String json) {
+        try {
+            return GSON.fromJson(json, RelayControlMessage.class);
+        } catch (JsonSyntaxException e) {
+            return null;
+        }
+    }
+
+    public String type() {
+        return type;
+    }
+
+    public String roomId() {
+        return roomId;
+    }
+
+    public String guestSessionId() {
+        return guestSessionId;
+    }
+
+    public String streamId() {
+        return streamId;
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayControlMessage.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayControlMessage.java
@@ -28,6 +28,55 @@ public class RelayControlMessage {
     @SerializedName("message")
     private String message;
 
+    @SerializedName("p2pSupported")
+    private boolean p2pSupported;
+
+    @SerializedName("p2pTransport")
+    private String p2pTransport;
+
+    @SerializedName("p2pProtocolVersion")
+    private int p2pProtocolVersion;
+
+    @SerializedName("p2pSessionId")
+    private String p2pSessionId;
+
+    @SerializedName("p2pToken")
+    private String p2pToken;
+
+    @SerializedName("p2pUdpHost")
+    private String p2pUdpHost;
+
+    @SerializedName("p2pUdpPort")
+    private int p2pUdpPort;
+
+    @SerializedName("p2pConnectTimeoutSeconds")
+    private int p2pConnectTimeoutSeconds;
+
+    @SerializedName("candidate")
+    private P2PCandidate candidate;
+
+    @SerializedName("role")
+    private String role;
+
+    @SerializedName("senderRole")
+    private String senderRole;
+
+    public static class P2PCandidate {
+        @SerializedName("address")
+        private String address;
+
+        @SerializedName("port")
+        private int port;
+
+        public String address() {
+            return address;
+        }
+
+        public int port() {
+            return port;
+        }
+    }
+
     public static RelayControlMessage fromJson(String json) {
         try {
             return GSON.fromJson(json, RelayControlMessage.class);
@@ -58,5 +107,49 @@ public class RelayControlMessage {
 
     public String message() {
         return message;
+    }
+
+    public boolean p2pSupported() {
+        return p2pSupported;
+    }
+
+    public String p2pTransport() {
+        return p2pTransport == null ? "" : p2pTransport;
+    }
+
+    public int p2pProtocolVersion() {
+        return p2pProtocolVersion;
+    }
+
+    public String p2pSessionId() {
+        return p2pSessionId;
+    }
+
+    public String p2pToken() {
+        return p2pToken;
+    }
+
+    public String p2pUdpHost() {
+        return p2pUdpHost;
+    }
+
+    public int p2pUdpPort() {
+        return p2pUdpPort;
+    }
+
+    public int p2pConnectTimeoutSeconds() {
+        return p2pConnectTimeoutSeconds;
+    }
+
+    public P2PCandidate candidate() {
+        return candidate;
+    }
+
+    public String role() {
+        return role;
+    }
+
+    public String senderRole() {
+        return senderRole;
     }
 }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
@@ -2,6 +2,7 @@ package firefly520.fireflymc.client.relay;
 
 import firefly520.fireflymc.Config;
 import firefly520.fireflymc.client.relay.p2p.P2PConnectionManager;
+import firefly520.fireflymc.client.relay.p2p.P2PGuestProxy;
 import firefly520.fireflymc.client.relay.p2p.P2PJoinInfo;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.ConnectScreen;
@@ -75,6 +76,9 @@ public final class RelayGuestJoiner {
                                         try {
                                             if (p2pError == null && result != null && result.success()) {
                                                 RelayLobbyState.setStatusMessage("P2P 连接成功");
+                                                P2PGuestProxy proxy = new P2PGuestProxy(result.channel());
+                                                proxy.start();
+                                                proxy.connectMinecraft(parent, room.worldName());
                                                 return;
                                             }
                                             RelayLobbyState.setStatusMessage("P2P 不可用，正在切换中继...");

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
@@ -9,14 +9,29 @@ import net.minecraft.network.chat.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 /**
  * Guest 加入公开房间流程。
  */
 public final class RelayGuestJoiner {
     private static final Logger LOGGER = LoggerFactory.getLogger(RelayGuestJoiner.class);
+    private static final ScheduledExecutorService EXECUTOR = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread thread = new Thread(r, "FireflyMC-Guest-Joiner");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private static final long CONNECT_TIMEOUT_SECONDS = 20;
+
     private static RelayGuestProxy activeProxy;
     private static String pendingRoomId;
     private static String pendingGuestSessionId;
+    private static final AtomicBoolean connectingToRelayRoom = new AtomicBoolean(false);
+    private static ScheduledFuture<?> connectTimeoutTask;
 
     private RelayGuestJoiner() {
     }
@@ -48,11 +63,17 @@ public final class RelayGuestJoiner {
     }
 
     public static void stopActiveRelay(String reason) {
+        if (connectingToRelayRoom.get() && activeProxy != null && !activeProxy.hasAcceptedClientConnection()) {
+            LOGGER.debug("[FireflyMC] 忽略连接阶段的断开事件，等待本地代理连接或超时: {}", reason);
+            return;
+        }
         if (activeProxy != null) {
             activeProxy.stop(reason);
             activeProxy = null;
             pendingRoomId = null;
             pendingGuestSessionId = null;
+            connectingToRelayRoom.set(false);
+            cancelConnectTimeout();
             return;
         }
         if (pendingRoomId != null && pendingGuestSessionId != null) {
@@ -61,6 +82,15 @@ public final class RelayGuestJoiner {
             );
             pendingRoomId = null;
             pendingGuestSessionId = null;
+            connectingToRelayRoom.set(false);
+            cancelConnectTimeout();
+        }
+    }
+
+    public static void markProxyAcceptedConnection(RelayGuestProxy proxy) {
+        if (activeProxy == proxy) {
+            connectingToRelayRoom.set(false);
+            cancelConnectTimeout();
         }
     }
 
@@ -74,6 +104,8 @@ public final class RelayGuestJoiner {
         RelayLobbyWebSocketClient.getInstance().setGuestProxy(activeProxy);
         pendingRoomId = room.roomId();
         pendingGuestSessionId = guestSessionId;
+        connectingToRelayRoom.set(true);
+        scheduleConnectTimeout(activeProxy);
 
         String addressText = "127.0.0.1:" + port;
         ServerAddress address = ServerAddress.parseString(addressText);
@@ -89,5 +121,38 @@ public final class RelayGuestJoiner {
                 false,
                 null
         );
+    }
+
+    private static void scheduleConnectTimeout(RelayGuestProxy proxy) {
+        cancelConnectTimeout();
+        connectTimeoutTask = EXECUTOR.schedule(() -> Minecraft.getInstance().execute(() -> {
+            if (activeProxy == proxy && connectingToRelayRoom.get() && !proxy.hasAcceptedClientConnection()) {
+                LOGGER.warn("[FireflyMC] 加入公开房间超时，本地客户端未连接代理，释放房间名额");
+                forceStopActiveRelay("connect_timeout");
+                RelayLobbyState.setStatusMessage("连接超时，已释放房间名额");
+            }
+        }), CONNECT_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+    }
+
+    private static void forceStopActiveRelay(String reason) {
+        if (activeProxy != null) {
+            activeProxy.stop(reason);
+            activeProxy = null;
+        } else if (pendingRoomId != null && pendingGuestSessionId != null) {
+            RelayLobbyWebSocketClient.getInstance().sendControl(
+                    RelayLobbyMessage.guestLeave(pendingRoomId, pendingGuestSessionId, reason)
+            );
+        }
+        pendingRoomId = null;
+        pendingGuestSessionId = null;
+        connectingToRelayRoom.set(false);
+        cancelConnectTimeout();
+    }
+
+    private static void cancelConnectTimeout() {
+        if (connectTimeoutTask != null) {
+            connectTimeoutTask.cancel(false);
+            connectTimeoutTask = null;
+        }
     }
 }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
@@ -4,14 +4,10 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.ConnectScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.multiplayer.ServerData;
-import net.minecraft.client.multiplayer.TransferState;
 import net.minecraft.client.multiplayer.resolver.ServerAddress;
 import net.minecraft.network.chat.Component;
-import net.minecraft.resources.ResourceLocation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Map;
 
 /**
  * Guest 加入公开房间流程。
@@ -67,7 +63,7 @@ public final class RelayGuestJoiner {
                 address,
                 serverData,
                 false,
-                new TransferState(Map.<ResourceLocation, byte[]>of())
+                null
         );
     }
 }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
@@ -1,5 +1,8 @@
 package firefly520.fireflymc.client.relay;
 
+import firefly520.fireflymc.Config;
+import firefly520.fireflymc.client.relay.p2p.P2PConnectionManager;
+import firefly520.fireflymc.client.relay.p2p.P2PJoinInfo;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.ConnectScreen;
 import net.minecraft.client.gui.screens.Screen;
@@ -44,13 +47,48 @@ public final class RelayGuestJoiner {
         String playerUuid = mc.getUser().getProfileId().toString();
         RelayLobbyWebSocketClient.getInstance()
                 .joinRoom(room, playerName, playerUuid)
-                .whenComplete((guestSessionId, error) -> mc.execute(() -> {
+                .whenComplete((joinAccepted, error) -> mc.execute(() -> {
                     if (error != null) {
                         RelayLobbyState.setStatusMessage("加入失败: " + error.getMessage());
                         LOGGER.warn("[FireflyMC] 加入公开房间失败: {}", error.getMessage());
                         return;
                     }
+                    String guestSessionId = joinAccepted.guestSessionId();
                     try {
+                        if (Config.CLIENT.SINGLEPLAYER_RELAY_P2P_ENABLED.get()
+                                && joinAccepted.p2pSupported()
+                            && "udp_reliable_v1".equals(joinAccepted.p2pTransport())) {
+                            RelayLobbyState.setStatusMessage("正在尝试 P2P 连接...");
+                            P2PJoinInfo info = new P2PJoinInfo(
+                                    room.roomId(),
+                                    guestSessionId,
+                                    joinAccepted.p2pSessionId(),
+                                    joinAccepted.p2pToken(),
+                                    joinAccepted.p2pUdpHost(),
+                                    joinAccepted.p2pUdpPort(),
+                                    joinAccepted.p2pConnectTimeoutSeconds() > 0
+                                            ? joinAccepted.p2pConnectTimeoutSeconds()
+                                            : Config.CLIENT.SINGLEPLAYER_RELAY_P2P_CONNECT_TIMEOUT_SECONDS.get()
+                            );
+                            P2PConnectionManager.getInstance().tryGuestConnect(info)
+                                    .whenComplete((result, p2pError) -> mc.execute(() -> {
+                                        try {
+                                            if (p2pError == null && result != null && result.success()) {
+                                                RelayLobbyState.setStatusMessage("P2P 连接成功");
+                                                return;
+                                            }
+                                            RelayLobbyState.setStatusMessage("P2P 不可用，正在切换中继...");
+                                            startProxyAndConnect(parent, room, guestSessionId);
+                                        } catch (Exception fallbackError) {
+                                            RelayLobbyWebSocketClient.getInstance().sendControl(
+                                                    RelayLobbyMessage.guestLeave(room.roomId(), guestSessionId, "proxy_start_failed")
+                                            );
+                                            RelayLobbyState.setStatusMessage("连接失败: " + fallbackError.getMessage());
+                                            LOGGER.warn("[FireflyMC] 回退中继失败: {}", fallbackError.getMessage());
+                                        }
+                                    }));
+                            return;
+                        }
                         startProxyAndConnect(parent, room, guestSessionId);
                     } catch (Exception e) {
                         RelayLobbyWebSocketClient.getInstance().sendControl(

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
@@ -1,0 +1,73 @@
+package firefly520.fireflymc.client.relay;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.ConnectScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.multiplayer.TransferState;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
+import net.minecraft.network.chat.Component;
+import net.minecraft.resources.ResourceLocation;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Map;
+
+/**
+ * Guest 加入公开房间流程。
+ */
+public final class RelayGuestJoiner {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RelayGuestJoiner.class);
+    private static RelayGuestProxy activeProxy;
+
+    private RelayGuestJoiner() {
+    }
+
+    public static void join(Screen parent, RelayLobbyRoom room) {
+        Minecraft mc = Minecraft.getInstance();
+        RelayLobbyState.setStatusMessage("正在加入房间: " + room.worldName());
+
+        String playerName = mc.getUser().getName();
+        String playerUuid = mc.getUser().getProfileId().toString();
+        RelayLobbyWebSocketClient.getInstance()
+                .joinRoom(room, playerName, playerUuid)
+                .whenComplete((guestSessionId, error) -> mc.execute(() -> {
+                    if (error != null) {
+                        RelayLobbyState.setStatusMessage("加入失败: " + error.getMessage());
+                        LOGGER.warn("[FireflyMC] 加入公开房间失败: {}", error.getMessage());
+                        return;
+                    }
+                    try {
+                        startProxyAndConnect(parent, room, guestSessionId);
+                    } catch (Exception e) {
+                        RelayLobbyState.setStatusMessage("连接失败: " + e.getMessage());
+                        LOGGER.warn("[FireflyMC] 启动本地代理失败: {}", e.getMessage());
+                    }
+                }));
+    }
+
+    private static void startProxyAndConnect(Screen parent, RelayLobbyRoom room, String guestSessionId) throws Exception {
+        if (activeProxy != null) {
+            activeProxy.stop();
+        }
+
+        activeProxy = new RelayGuestProxy(room.roomId(), guestSessionId);
+        int port = activeProxy.start();
+        RelayLobbyWebSocketClient.getInstance().setGuestProxy(activeProxy);
+
+        String addressText = "127.0.0.1:" + port;
+        ServerAddress address = ServerAddress.parseString(addressText);
+        ServerData serverData = new ServerData("FireflyMC - " + room.worldName(), addressText, ServerData.Type.OTHER);
+        RelayLobbyState.setStatusMessage("正在连接本地代理: " + addressText);
+        LOGGER.info("[FireflyMC] 正在通过本地代理加入房间: roomId={}, address={}", room.roomId(), addressText);
+
+        ConnectScreen.startConnecting(
+                parent,
+                Minecraft.getInstance(),
+                address,
+                serverData,
+                false,
+                new TransferState(Map.<ResourceLocation, byte[]>of())
+        );
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestJoiner.java
@@ -15,6 +15,8 @@ import org.slf4j.LoggerFactory;
 public final class RelayGuestJoiner {
     private static final Logger LOGGER = LoggerFactory.getLogger(RelayGuestJoiner.class);
     private static RelayGuestProxy activeProxy;
+    private static String pendingRoomId;
+    private static String pendingGuestSessionId;
 
     private RelayGuestJoiner() {
     }
@@ -36,10 +38,30 @@ public final class RelayGuestJoiner {
                     try {
                         startProxyAndConnect(parent, room, guestSessionId);
                     } catch (Exception e) {
+                        RelayLobbyWebSocketClient.getInstance().sendControl(
+                                RelayLobbyMessage.guestLeave(room.roomId(), guestSessionId, "proxy_start_failed")
+                        );
                         RelayLobbyState.setStatusMessage("连接失败: " + e.getMessage());
                         LOGGER.warn("[FireflyMC] 启动本地代理失败: {}", e.getMessage());
                     }
                 }));
+    }
+
+    public static void stopActiveRelay(String reason) {
+        if (activeProxy != null) {
+            activeProxy.stop(reason);
+            activeProxy = null;
+            pendingRoomId = null;
+            pendingGuestSessionId = null;
+            return;
+        }
+        if (pendingRoomId != null && pendingGuestSessionId != null) {
+            RelayLobbyWebSocketClient.getInstance().sendControl(
+                    RelayLobbyMessage.guestLeave(pendingRoomId, pendingGuestSessionId, reason)
+            );
+            pendingRoomId = null;
+            pendingGuestSessionId = null;
+        }
     }
 
     private static void startProxyAndConnect(Screen parent, RelayLobbyRoom room, String guestSessionId) throws Exception {
@@ -50,6 +72,8 @@ public final class RelayGuestJoiner {
         activeProxy = new RelayGuestProxy(room.roomId(), guestSessionId);
         int port = activeProxy.start();
         RelayLobbyWebSocketClient.getInstance().setGuestProxy(activeProxy);
+        pendingRoomId = room.roomId();
+        pendingGuestSessionId = guestSessionId;
 
         String addressText = "127.0.0.1:" + port;
         ServerAddress address = ServerAddress.parseString(addressText);

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestProxy.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestProxy.java
@@ -29,6 +29,7 @@ public class RelayGuestProxy {
 
     private final String roomId;
     private final String guestSessionId;
+    private final AtomicBoolean leaveSent = new AtomicBoolean(false);
     private final ExecutorService executor = Executors.newCachedThreadPool(r -> {
         Thread thread = new Thread(r, "FireflyMC-Guest-Proxy");
         thread.setDaemon(true);
@@ -61,6 +62,10 @@ public class RelayGuestProxy {
     }
 
     public void stop() {
+        stop("guest_stopped");
+    }
+
+    public void stop(String reason) {
         running.set(false);
         try {
             if (serverSocket != null) {
@@ -75,7 +80,17 @@ public class RelayGuestProxy {
             }
         });
         streamSockets.clear();
+        sendGuestLeave(reason);
+        RelayLobbyWebSocketClient.getInstance().clearGuestProxy(this);
         executor.shutdownNow();
+    }
+
+    public String guestSessionId() {
+        return guestSessionId;
+    }
+
+    public String roomId() {
+        return roomId;
     }
 
     public boolean handleBinary(byte[] bytes) {
@@ -154,6 +169,15 @@ public class RelayGuestProxy {
             } catch (IOException ignored) {
             }
             RelayLobbyWebSocketClient.getInstance().sendControl(RelayLobbyMessage.streamClose(roomId, streamId, reason));
+        }
+        if (streamSockets.isEmpty()) {
+            sendGuestLeave(reason);
+        }
+    }
+
+    private void sendGuestLeave(String reason) {
+        if (leaveSent.compareAndSet(false, true)) {
+            RelayLobbyWebSocketClient.getInstance().sendControl(RelayLobbyMessage.guestLeave(roomId, guestSessionId, reason));
         }
     }
 }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestProxy.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestProxy.java
@@ -1,0 +1,141 @@
+package firefly520.fireflymc.client.relay;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Guest 侧本地 TCP 代理。
+ */
+public class RelayGuestProxy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RelayGuestProxy.class);
+    private static final int STREAM_ID_LENGTH = 36;
+
+    private final String roomId;
+    private final String guestSessionId;
+    private final ExecutorService executor = Executors.newCachedThreadPool(r -> {
+        Thread thread = new Thread(r, "FireflyMC-Guest-Proxy");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final Map<String, Socket> streamSockets = new ConcurrentHashMap<>();
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    private ServerSocket serverSocket;
+    private int localPort = -1;
+
+    public RelayGuestProxy(String roomId, String guestSessionId) {
+        this.roomId = roomId;
+        this.guestSessionId = guestSessionId;
+    }
+
+    public int start() throws IOException {
+        if (!running.compareAndSet(false, true)) {
+            return localPort;
+        }
+
+        serverSocket = new ServerSocket(0);
+        serverSocket.setReuseAddress(true);
+        localPort = serverSocket.getLocalPort();
+        executor.execute(this::acceptLoop);
+        LOGGER.info("[FireflyMC] Guest 本地代理已启动: 127.0.0.1:{}", localPort);
+        return localPort;
+    }
+
+    public void stop() {
+        running.set(false);
+        try {
+            if (serverSocket != null) {
+                serverSocket.close();
+            }
+        } catch (IOException ignored) {
+        }
+        streamSockets.values().forEach(socket -> {
+            try {
+                socket.close();
+            } catch (IOException ignored) {
+            }
+        });
+        streamSockets.clear();
+        executor.shutdownNow();
+    }
+
+    public boolean handleBinary(byte[] bytes) {
+        if (bytes.length <= STREAM_ID_LENGTH) {
+            return false;
+        }
+        String streamId = new String(bytes, 0, STREAM_ID_LENGTH, StandardCharsets.UTF_8);
+        Socket socket = streamSockets.get(streamId);
+        if (socket == null || socket.isClosed()) {
+            return false;
+        }
+        try {
+            OutputStream output = socket.getOutputStream();
+            output.write(bytes, STREAM_ID_LENGTH, bytes.length - STREAM_ID_LENGTH);
+            output.flush();
+            return true;
+        } catch (IOException e) {
+            closeStream(streamId, "write_failed");
+            return false;
+        }
+    }
+
+    private void acceptLoop() {
+        while (running.get()) {
+            try {
+                Socket socket = serverSocket.accept();
+                socket.setTcpNoDelay(true);
+                String streamId = UUID.randomUUID().toString();
+                streamSockets.put(streamId, socket);
+                RelayLobbyWebSocketClient.getInstance().sendControl(RelayLobbyMessage.streamOpen(roomId, guestSessionId, streamId));
+                executor.execute(() -> pipeLocalToRelay(streamId, socket));
+            } catch (IOException e) {
+                if (running.get()) {
+                    LOGGER.warn("[FireflyMC] Guest 本地代理接受连接失败: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    private void pipeLocalToRelay(String streamId, Socket socket) {
+        byte[] buffer = new byte[8192];
+        try (InputStream input = socket.getInputStream()) {
+            int read;
+            while (running.get() && (read = input.read(buffer)) != -1) {
+                byte[] frame = new byte[STREAM_ID_LENGTH + read];
+                byte[] streamBytes = streamId.getBytes(StandardCharsets.UTF_8);
+                System.arraycopy(streamBytes, 0, frame, 0, STREAM_ID_LENGTH);
+                System.arraycopy(buffer, 0, frame, STREAM_ID_LENGTH, read);
+                RelayLobbyWebSocketClient.getInstance().sendBinary(ByteBuffer.wrap(frame));
+            }
+        } catch (IOException e) {
+            LOGGER.debug("[FireflyMC] Guest 本地代理流关闭: {}", e.getMessage());
+        } finally {
+            closeStream(streamId, "local_closed");
+        }
+    }
+
+    private void closeStream(String streamId, String reason) {
+        Socket socket = streamSockets.remove(streamId);
+        if (socket != null) {
+            try {
+                socket.close();
+            } catch (IOException ignored) {
+            }
+            RelayLobbyWebSocketClient.getInstance().sendControl(RelayLobbyMessage.streamClose(roomId, streamId, reason));
+        }
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestProxy.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestProxy.java
@@ -37,6 +37,7 @@ public class RelayGuestProxy {
     });
     private final Map<String, Socket> streamSockets = new ConcurrentHashMap<>();
     private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicBoolean acceptedClientConnection = new AtomicBoolean(false);
     private final AtomicLong guestToRelayBytes = new AtomicLong(0);
     private final AtomicLong relayToGuestBytes = new AtomicLong(0);
 
@@ -93,6 +94,10 @@ public class RelayGuestProxy {
         return roomId;
     }
 
+    public boolean hasAcceptedClientConnection() {
+        return acceptedClientConnection.get();
+    }
+
     public boolean handleBinary(byte[] bytes) {
         if (bytes.length <= STREAM_ID_LENGTH) {
             return false;
@@ -126,6 +131,8 @@ public class RelayGuestProxy {
                 socket.setTcpNoDelay(true);
                 socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
                 socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
+                acceptedClientConnection.set(true);
+                RelayGuestJoiner.markProxyAcceptedConnection(this);
                 String streamId = UUID.randomUUID().toString();
                 streamSockets.put(streamId, socket);
                 RelayLobbyWebSocketClient.getInstance().sendControl(RelayLobbyMessage.streamOpen(roomId, guestSessionId, streamId));

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestProxy.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestProxy.java
@@ -24,8 +24,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public class RelayGuestProxy {
     private static final Logger LOGGER = LoggerFactory.getLogger(RelayGuestProxy.class);
     private static final int STREAM_ID_LENGTH = 36;
-    private static final int RELAY_BUFFER_SIZE = 64 * 1024;
-    private static final int SOCKET_BUFFER_SIZE = 256 * 1024;
+    private static final int RELAY_BUFFER_SIZE = 512 * 1024;
+    private static final int SOCKET_BUFFER_SIZE = 2 * 1024 * 1024;
 
     private final String roomId;
     private final String guestSessionId;

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayGuestProxy.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayGuestProxy.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Guest 侧本地 TCP 代理。
@@ -23,6 +24,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class RelayGuestProxy {
     private static final Logger LOGGER = LoggerFactory.getLogger(RelayGuestProxy.class);
     private static final int STREAM_ID_LENGTH = 36;
+    private static final int RELAY_BUFFER_SIZE = 64 * 1024;
+    private static final int SOCKET_BUFFER_SIZE = 256 * 1024;
 
     private final String roomId;
     private final String guestSessionId;
@@ -33,6 +36,8 @@ public class RelayGuestProxy {
     });
     private final Map<String, Socket> streamSockets = new ConcurrentHashMap<>();
     private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicLong guestToRelayBytes = new AtomicLong(0);
+    private final AtomicLong relayToGuestBytes = new AtomicLong(0);
 
     private ServerSocket serverSocket;
     private int localPort = -1;
@@ -80,12 +85,18 @@ public class RelayGuestProxy {
         String streamId = new String(bytes, 0, STREAM_ID_LENGTH, StandardCharsets.UTF_8);
         Socket socket = streamSockets.get(streamId);
         if (socket == null || socket.isClosed()) {
+            LOGGER.debug("[FireflyMC] Guest 收到二进制但无对应流: streamId={}, bytes={}", streamId, bytes.length);
             return false;
         }
         try {
+            int payloadLen = bytes.length - STREAM_ID_LENGTH;
             OutputStream output = socket.getOutputStream();
-            output.write(bytes, STREAM_ID_LENGTH, bytes.length - STREAM_ID_LENGTH);
+            output.write(bytes, STREAM_ID_LENGTH, payloadLen);
             output.flush();
+            relayToGuestBytes.addAndGet(payloadLen);
+            if (payloadLen > 1000) {
+                LOGGER.debug("[FireflyMC] Guest relay→本地: {} bytes, total relay→guest: {} KB", payloadLen, relayToGuestBytes.get() / 1024);
+            }
             return true;
         } catch (IOException e) {
             closeStream(streamId, "write_failed");
@@ -98,6 +109,8 @@ public class RelayGuestProxy {
             try {
                 Socket socket = serverSocket.accept();
                 socket.setTcpNoDelay(true);
+                socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
+                socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
                 String streamId = UUID.randomUUID().toString();
                 streamSockets.put(streamId, socket);
                 RelayLobbyWebSocketClient.getInstance().sendControl(RelayLobbyMessage.streamOpen(roomId, guestSessionId, streamId));
@@ -111,7 +124,7 @@ public class RelayGuestProxy {
     }
 
     private void pipeLocalToRelay(String streamId, Socket socket) {
-        byte[] buffer = new byte[8192];
+        byte[] buffer = new byte[RELAY_BUFFER_SIZE];
         try (InputStream input = socket.getInputStream()) {
             int read;
             while (running.get() && (read = input.read(buffer)) != -1) {
@@ -120,10 +133,15 @@ public class RelayGuestProxy {
                 System.arraycopy(streamBytes, 0, frame, 0, STREAM_ID_LENGTH);
                 System.arraycopy(buffer, 0, frame, STREAM_ID_LENGTH, read);
                 RelayLobbyWebSocketClient.getInstance().sendBinary(ByteBuffer.wrap(frame));
+                guestToRelayBytes.addAndGet(read);
+                if (read > 1000) {
+                    LOGGER.debug("[FireflyMC] Guest 本地→relay: {} bytes, total guest→relay: {} KB", read, guestToRelayBytes.get() / 1024);
+                }
             }
         } catch (IOException e) {
             LOGGER.debug("[FireflyMC] Guest 本地代理流关闭: {}", e.getMessage());
         } finally {
+            LOGGER.info("[FireflyMC] Guest 流结束: streamId={}, sent {} KB, recv {} KB", streamId, guestToRelayBytes.get() / 1024, relayToGuestBytes.get() / 1024);
             closeStream(streamId, "local_closed");
         }
     }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayHostBridge.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayHostBridge.java
@@ -21,8 +21,8 @@ import java.util.concurrent.atomic.AtomicLong;
 public class RelayHostBridge {
     private static final Logger LOGGER = LoggerFactory.getLogger(RelayHostBridge.class);
     private static final int STREAM_ID_LENGTH = 36;
-    private static final int RELAY_BUFFER_SIZE = 64 * 1024;
-    private static final int SOCKET_BUFFER_SIZE = 256 * 1024;
+    private static final int RELAY_BUFFER_SIZE = 512 * 1024;
+    private static final int SOCKET_BUFFER_SIZE = 2 * 1024 * 1024;
 
     private final int lanPort;
     private final AtomicLong hostToRelayBytes = new AtomicLong(0);

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayHostBridge.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayHostBridge.java
@@ -1,0 +1,107 @@
+package firefly520.fireflymc.client.relay;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Host 侧 LAN TCP 桥接。
+ */
+public class RelayHostBridge {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RelayHostBridge.class);
+    private static final int STREAM_ID_LENGTH = 36;
+
+    private final int lanPort;
+    private final ExecutorService executor = Executors.newCachedThreadPool(r -> {
+        Thread thread = new Thread(r, "FireflyMC-Host-Bridge");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final Map<String, Socket> streamSockets = new ConcurrentHashMap<>();
+
+    public RelayHostBridge(int lanPort) {
+        this.lanPort = lanPort;
+    }
+
+    public void openStream(String streamId) {
+        if (streamSockets.containsKey(streamId)) {
+            return;
+        }
+        executor.execute(() -> {
+            try {
+                Socket socket = new Socket("127.0.0.1", lanPort);
+                socket.setTcpNoDelay(true);
+                streamSockets.put(streamId, socket);
+                LOGGER.info("[FireflyMC] Host 桥接已连接本地 LAN: streamId={}, port={}", streamId, lanPort);
+                pipeLanToRelay(streamId, socket);
+            } catch (IOException e) {
+                LOGGER.warn("[FireflyMC] Host 桥接连接本地 LAN 失败: {}", e.getMessage());
+                RelayLobbyWebSocketClient.getInstance().sendControl(RelayLobbyMessage.streamClose(null, streamId, "host_connect_failed"));
+            }
+        });
+    }
+
+    public boolean handleBinary(byte[] bytes) {
+        if (bytes.length <= STREAM_ID_LENGTH) {
+            return false;
+        }
+        String streamId = new String(bytes, 0, STREAM_ID_LENGTH, StandardCharsets.UTF_8);
+        Socket socket = streamSockets.get(streamId);
+        if (socket == null || socket.isClosed()) {
+            return false;
+        }
+        try {
+            OutputStream output = socket.getOutputStream();
+            output.write(bytes, STREAM_ID_LENGTH, bytes.length - STREAM_ID_LENGTH);
+            output.flush();
+            return true;
+        } catch (IOException e) {
+            closeStream(streamId, "host_write_failed");
+            return false;
+        }
+    }
+
+    public void closeStream(String streamId, String reason) {
+        Socket socket = streamSockets.remove(streamId);
+        if (socket != null) {
+            try {
+                socket.close();
+            } catch (IOException ignored) {
+            }
+            RelayLobbyWebSocketClient.getInstance().sendControl(RelayLobbyMessage.streamClose(null, streamId, reason));
+        }
+    }
+
+    public void stop() {
+        streamSockets.keySet().forEach(streamId -> closeStream(streamId, "host_stopped"));
+        executor.shutdownNow();
+    }
+
+    private void pipeLanToRelay(String streamId, Socket socket) {
+        byte[] buffer = new byte[8192];
+        try (InputStream input = socket.getInputStream()) {
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                byte[] frame = new byte[STREAM_ID_LENGTH + read];
+                byte[] streamBytes = streamId.getBytes(StandardCharsets.UTF_8);
+                System.arraycopy(streamBytes, 0, frame, 0, STREAM_ID_LENGTH);
+                System.arraycopy(buffer, 0, frame, STREAM_ID_LENGTH, read);
+                RelayLobbyWebSocketClient.getInstance().sendBinary(ByteBuffer.wrap(frame));
+            }
+        } catch (IOException e) {
+            LOGGER.debug("[FireflyMC] Host LAN 流关闭: {}", e.getMessage());
+        } finally {
+            closeStream(streamId, "host_local_closed");
+        }
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayHostBridge.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayHostBridge.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Host 侧 LAN TCP 桥接。
@@ -20,8 +21,12 @@ import java.util.concurrent.Executors;
 public class RelayHostBridge {
     private static final Logger LOGGER = LoggerFactory.getLogger(RelayHostBridge.class);
     private static final int STREAM_ID_LENGTH = 36;
+    private static final int RELAY_BUFFER_SIZE = 64 * 1024;
+    private static final int SOCKET_BUFFER_SIZE = 256 * 1024;
 
     private final int lanPort;
+    private final AtomicLong hostToRelayBytes = new AtomicLong(0);
+    private final AtomicLong relayToHostBytes = new AtomicLong(0);
     private final ExecutorService executor = Executors.newCachedThreadPool(r -> {
         Thread thread = new Thread(r, "FireflyMC-Host-Bridge");
         thread.setDaemon(true);
@@ -41,6 +46,8 @@ public class RelayHostBridge {
             try {
                 Socket socket = new Socket("127.0.0.1", lanPort);
                 socket.setTcpNoDelay(true);
+                socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
+                socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
                 streamSockets.put(streamId, socket);
                 LOGGER.info("[FireflyMC] Host 桥接已连接本地 LAN: streamId={}, port={}", streamId, lanPort);
                 pipeLanToRelay(streamId, socket);
@@ -58,12 +65,18 @@ public class RelayHostBridge {
         String streamId = new String(bytes, 0, STREAM_ID_LENGTH, StandardCharsets.UTF_8);
         Socket socket = streamSockets.get(streamId);
         if (socket == null || socket.isClosed()) {
+            LOGGER.debug("[FireflyMC] Host 收到二进制但无对应流: streamId={}, bytes={}", streamId, bytes.length);
             return false;
         }
         try {
+            int payloadLen = bytes.length - STREAM_ID_LENGTH;
             OutputStream output = socket.getOutputStream();
-            output.write(bytes, STREAM_ID_LENGTH, bytes.length - STREAM_ID_LENGTH);
+            output.write(bytes, STREAM_ID_LENGTH, payloadLen);
             output.flush();
+            relayToHostBytes.addAndGet(payloadLen);
+            if (payloadLen > 1000) {
+                LOGGER.debug("[FireflyMC] Host relay→LAN: {} bytes, total relay→host: {} KB", payloadLen, relayToHostBytes.get() / 1024);
+            }
             return true;
         } catch (IOException e) {
             closeStream(streamId, "host_write_failed");
@@ -88,7 +101,7 @@ public class RelayHostBridge {
     }
 
     private void pipeLanToRelay(String streamId, Socket socket) {
-        byte[] buffer = new byte[8192];
+        byte[] buffer = new byte[RELAY_BUFFER_SIZE];
         try (InputStream input = socket.getInputStream()) {
             int read;
             while ((read = input.read(buffer)) != -1) {
@@ -97,10 +110,15 @@ public class RelayHostBridge {
                 System.arraycopy(streamBytes, 0, frame, 0, STREAM_ID_LENGTH);
                 System.arraycopy(buffer, 0, frame, STREAM_ID_LENGTH, read);
                 RelayLobbyWebSocketClient.getInstance().sendBinary(ByteBuffer.wrap(frame));
+                hostToRelayBytes.addAndGet(read);
+                if (read > 1000) {
+                    LOGGER.debug("[FireflyMC] Host LAN→relay: {} bytes, total host→relay: {} KB", read, hostToRelayBytes.get() / 1024);
+                }
             }
         } catch (IOException e) {
             LOGGER.debug("[FireflyMC] Host LAN 流关闭: {}", e.getMessage());
         } finally {
+            LOGGER.info("[FireflyMC] Host 流结束: streamId={}, sent {} KB, recv {} KB", streamId, hostToRelayBytes.get() / 1024, relayToHostBytes.get() / 1024);
             closeStream(streamId, "host_local_closed");
         }
     }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyListResult.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyListResult.java
@@ -1,0 +1,36 @@
+package firefly520.fireflymc.client.relay;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+/**
+ * 公开大厅列表响应。
+ */
+public class RelayLobbyListResult {
+    private static final Gson GSON = new Gson();
+
+    @SerializedName("type")
+    private String type;
+
+    @SerializedName("rooms")
+    private List<RelayLobbyRoom> rooms;
+
+    public static RelayLobbyListResult fromJson(String json) {
+        try {
+            return GSON.fromJson(json, RelayLobbyListResult.class);
+        } catch (JsonSyntaxException e) {
+            return null;
+        }
+    }
+
+    public boolean isLobbyListResult() {
+        return "lobby_list_result".equals(type) || "lobby_update".equals(type);
+    }
+
+    public List<RelayLobbyRoom> rooms() {
+        return rooms == null ? List.of() : rooms;
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyMessage.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyMessage.java
@@ -106,6 +106,11 @@ public final class RelayLobbyMessage {
                 guestPlayerName, guestUuid, null, null, null);
     }
 
+    public static RelayLobbyMessage guestLeave(String roomId, String guestSessionId, String reason) {
+        return new RelayLobbyMessage("guest_leave", roomId, null, null, null, -1, -1,
+                null, null, guestSessionId, null, reason);
+    }
+
     public static RelayLobbyMessage streamOpen(String roomId, String guestSessionId, String streamId) {
         return new RelayLobbyMessage("stream_open", roomId, null, null, null, -1, -1,
                 null, null, guestSessionId, streamId, null);

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyMessage.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyMessage.java
@@ -49,6 +49,21 @@ public final class RelayLobbyMessage {
     @SerializedName("reason")
     private final String reason;
 
+    @SerializedName("p2pSupported")
+    private final boolean p2pSupported;
+
+    @SerializedName("p2pTransport")
+    private final String p2pTransport;
+
+    @SerializedName("p2pProtocolVersion")
+    private final int p2pProtocolVersion;
+
+    @SerializedName("p2pSessionId")
+    private final String p2pSessionId;
+
+    @SerializedName("p2pToken")
+    private final String p2pToken;
+
     @SerializedName("modVersion")
     private final String modVersion;
 
@@ -67,6 +82,15 @@ public final class RelayLobbyMessage {
         private RelayLobbyMessage(String type, String roomId, String worldName, String hostPlayerName,
                       String hostUuid, int lanPort, int maxPlayers, String guestPlayerName,
                       String guestUuid, String guestSessionId, String streamId, String reason) {
+        this(type, roomId, worldName, hostPlayerName, hostUuid, lanPort, maxPlayers, guestPlayerName, guestUuid,
+            guestSessionId, streamId, reason, false, null, 0, null, null);
+        }
+
+        private RelayLobbyMessage(String type, String roomId, String worldName, String hostPlayerName,
+                  String hostUuid, int lanPort, int maxPlayers, String guestPlayerName,
+                  String guestUuid, String guestSessionId, String streamId, String reason,
+                  boolean p2pSupported, String p2pTransport, int p2pProtocolVersion,
+                  String p2pSessionId, String p2pToken) {
         this.type = type;
         this.roomId = roomId;
         this.worldName = worldName;
@@ -79,6 +103,35 @@ public final class RelayLobbyMessage {
         this.guestSessionId = guestSessionId;
         this.streamId = streamId;
         this.reason = reason;
+        this.p2pSupported = p2pSupported;
+        this.p2pTransport = p2pTransport;
+        this.p2pProtocolVersion = p2pProtocolVersion;
+        this.p2pSessionId = p2pSessionId;
+        this.p2pToken = p2pToken;
+        this.modVersion = FireflyMCMod.VERSION;
+        this.minecraftVersion = "1.21.1";
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    private RelayLobbyMessage(String type, String roomId, String guestSessionId, String p2pSessionId,
+                              String p2pToken, String reason) {
+        this.type = type;
+        this.roomId = roomId;
+        this.worldName = null;
+        this.hostPlayerName = null;
+        this.hostUuid = null;
+        this.lanPort = -1;
+        this.maxPlayers = -1;
+        this.guestPlayerName = null;
+        this.guestUuid = null;
+        this.guestSessionId = guestSessionId;
+        this.streamId = null;
+        this.reason = reason;
+        this.p2pSupported = true;
+        this.p2pTransport = "udp_reliable_v1";
+        this.p2pProtocolVersion = 1;
+        this.p2pSessionId = p2pSessionId;
+        this.p2pToken = p2pToken;
         this.modVersion = FireflyMCMod.VERSION;
         this.minecraftVersion = "1.21.1";
         this.timestamp = System.currentTimeMillis();
@@ -87,6 +140,13 @@ public final class RelayLobbyMessage {
     public static RelayLobbyMessage hostOpen(String roomId, String worldName, String hostPlayerName,
                                              String hostUuid, int lanPort, int maxPlayers) {
         return new RelayLobbyMessage("host_open", roomId, worldName, hostPlayerName, hostUuid, lanPort, maxPlayers);
+    }
+
+    public static RelayLobbyMessage hostOpenP2P(String roomId, String worldName, String hostPlayerName,
+                                                String hostUuid, int lanPort, int maxPlayers,
+                                                String p2pSessionId) {
+        return new RelayLobbyMessage("host_open", roomId, worldName, hostPlayerName, hostUuid, lanPort, maxPlayers,
+                null, null, null, null, null, true, "udp_reliable_v1", 1, p2pSessionId, null);
     }
 
     public static RelayLobbyMessage hostClose(String roomId) {
@@ -119,6 +179,22 @@ public final class RelayLobbyMessage {
     public static RelayLobbyMessage streamClose(String roomId, String streamId, String reason) {
         return new RelayLobbyMessage("stream_close", roomId, null, null, null, -1, -1,
                 null, null, null, streamId, reason);
+    }
+
+    public static RelayLobbyMessage p2pOffer(String roomId, String guestSessionId, String p2pSessionId, String p2pToken) {
+        return new RelayLobbyMessage("p2p_offer", roomId, guestSessionId, p2pSessionId, p2pToken, null);
+    }
+
+    public static RelayLobbyMessage p2pReady(String roomId, String guestSessionId, String p2pSessionId, String p2pToken) {
+        return new RelayLobbyMessage("p2p_ready", roomId, guestSessionId, p2pSessionId, p2pToken, null);
+    }
+
+    public static RelayLobbyMessage p2pFailed(String roomId, String guestSessionId, String p2pSessionId, String p2pToken, String reason) {
+        return new RelayLobbyMessage("p2p_failed", roomId, guestSessionId, p2pSessionId, p2pToken, reason);
+    }
+
+    public static RelayLobbyMessage relayFallback(String roomId, String guestSessionId, String p2pSessionId, String p2pToken, String reason) {
+        return new RelayLobbyMessage("relay_fallback", roomId, guestSessionId, p2pSessionId, p2pToken, reason);
     }
 
     public String type() {
@@ -160,6 +236,21 @@ public final class RelayLobbyMessage {
         }
         if (reason != null) {
             json.addProperty("reason", reason);
+        }
+        if (p2pSupported) {
+            json.addProperty("p2pSupported", true);
+        }
+        if (p2pTransport != null) {
+            json.addProperty("p2pTransport", p2pTransport);
+        }
+        if (p2pProtocolVersion > 0) {
+            json.addProperty("p2pProtocolVersion", p2pProtocolVersion);
+        }
+        if (p2pSessionId != null) {
+            json.addProperty("p2pSessionId", p2pSessionId);
+        }
+        if (p2pToken != null) {
+            json.addProperty("p2pToken", p2pToken);
         }
         json.addProperty("modVersion", modVersion);
         json.addProperty("minecraftVersion", minecraftVersion);

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyMessage.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyMessage.java
@@ -1,0 +1,107 @@
+package firefly520.fireflymc.client.relay;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.annotations.SerializedName;
+import firefly520.fireflymc.FireflyMCMod;
+
+/**
+ * 单人世界公开大厅控制消息。
+ *
+ * 阶段二先实现房间注册/关闭的 JSON 协议骨架；后续二进制流量中继会使用独立 stream 消息。
+ */
+public final class RelayLobbyMessage {
+    private static final Gson GSON = new Gson();
+
+    @SerializedName("type")
+    private final String type;
+
+    @SerializedName("roomId")
+    private final String roomId;
+
+    @SerializedName("worldName")
+    private final String worldName;
+
+    @SerializedName("hostPlayerName")
+    private final String hostPlayerName;
+
+    @SerializedName("hostUuid")
+    private final String hostUuid;
+
+    @SerializedName("lanPort")
+    private final int lanPort;
+
+    @SerializedName("maxPlayers")
+    private final int maxPlayers;
+
+    @SerializedName("modVersion")
+    private final String modVersion;
+
+    @SerializedName("minecraftVersion")
+    private final String minecraftVersion;
+
+    @SerializedName("timestamp")
+    private final long timestamp;
+
+    private RelayLobbyMessage(String type, String roomId, String worldName, String hostPlayerName,
+                              String hostUuid, int lanPort, int maxPlayers) {
+        this.type = type;
+        this.roomId = roomId;
+        this.worldName = worldName;
+        this.hostPlayerName = hostPlayerName;
+        this.hostUuid = hostUuid;
+        this.lanPort = lanPort;
+        this.maxPlayers = maxPlayers;
+        this.modVersion = FireflyMCMod.VERSION;
+        this.minecraftVersion = "1.21.1";
+        this.timestamp = System.currentTimeMillis();
+    }
+
+    public static RelayLobbyMessage hostOpen(String roomId, String worldName, String hostPlayerName,
+                                             String hostUuid, int lanPort, int maxPlayers) {
+        return new RelayLobbyMessage("host_open", roomId, worldName, hostPlayerName, hostUuid, lanPort, maxPlayers);
+    }
+
+    public static RelayLobbyMessage hostClose(String roomId) {
+        return new RelayLobbyMessage("host_close", roomId, null, null, null, -1, -1);
+    }
+
+    public static RelayLobbyMessage heartbeat(String roomId) {
+        return new RelayLobbyMessage("heartbeat", roomId, null, null, null, -1, -1);
+    }
+
+    public static RelayLobbyMessage lobbyList() {
+        return new RelayLobbyMessage("lobby_list", null, null, null, null, -1, -1);
+    }
+
+    public String type() {
+        return type;
+    }
+
+    public String toJson() {
+        JsonObject json = new JsonObject();
+        json.addProperty("type", type);
+        if (roomId != null) {
+            json.addProperty("roomId", roomId);
+        }
+        if (worldName != null) {
+            json.addProperty("worldName", worldName);
+        }
+        if (hostPlayerName != null) {
+            json.addProperty("hostPlayerName", hostPlayerName);
+        }
+        if (hostUuid != null) {
+            json.addProperty("hostUuid", hostUuid);
+        }
+        if (lanPort >= 0) {
+            json.addProperty("lanPort", lanPort);
+        }
+        if (maxPlayers >= 0) {
+            json.addProperty("maxPlayers", maxPlayers);
+        }
+        json.addProperty("modVersion", modVersion);
+        json.addProperty("minecraftVersion", minecraftVersion);
+        json.addProperty("timestamp", timestamp);
+        return GSON.toJson(json);
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyMessage.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyMessage.java
@@ -34,6 +34,21 @@ public final class RelayLobbyMessage {
     @SerializedName("maxPlayers")
     private final int maxPlayers;
 
+    @SerializedName("guestPlayerName")
+    private final String guestPlayerName;
+
+    @SerializedName("guestUuid")
+    private final String guestUuid;
+
+    @SerializedName("guestSessionId")
+    private final String guestSessionId;
+
+    @SerializedName("streamId")
+    private final String streamId;
+
+    @SerializedName("reason")
+    private final String reason;
+
     @SerializedName("modVersion")
     private final String modVersion;
 
@@ -45,6 +60,13 @@ public final class RelayLobbyMessage {
 
     private RelayLobbyMessage(String type, String roomId, String worldName, String hostPlayerName,
                               String hostUuid, int lanPort, int maxPlayers) {
+        this(type, roomId, worldName, hostPlayerName, hostUuid, lanPort, maxPlayers,
+            null, null, null, null, null);
+        }
+
+        private RelayLobbyMessage(String type, String roomId, String worldName, String hostPlayerName,
+                      String hostUuid, int lanPort, int maxPlayers, String guestPlayerName,
+                      String guestUuid, String guestSessionId, String streamId, String reason) {
         this.type = type;
         this.roomId = roomId;
         this.worldName = worldName;
@@ -52,6 +74,11 @@ public final class RelayLobbyMessage {
         this.hostUuid = hostUuid;
         this.lanPort = lanPort;
         this.maxPlayers = maxPlayers;
+        this.guestPlayerName = guestPlayerName;
+        this.guestUuid = guestUuid;
+        this.guestSessionId = guestSessionId;
+        this.streamId = streamId;
+        this.reason = reason;
         this.modVersion = FireflyMCMod.VERSION;
         this.minecraftVersion = "1.21.1";
         this.timestamp = System.currentTimeMillis();
@@ -72,6 +99,21 @@ public final class RelayLobbyMessage {
 
     public static RelayLobbyMessage lobbyList() {
         return new RelayLobbyMessage("lobby_list", null, null, null, null, -1, -1);
+    }
+
+    public static RelayLobbyMessage guestJoin(String roomId, String guestPlayerName, String guestUuid) {
+        return new RelayLobbyMessage("guest_join", roomId, null, null, null, -1, -1,
+                guestPlayerName, guestUuid, null, null, null);
+    }
+
+    public static RelayLobbyMessage streamOpen(String roomId, String guestSessionId, String streamId) {
+        return new RelayLobbyMessage("stream_open", roomId, null, null, null, -1, -1,
+                null, null, guestSessionId, streamId, null);
+    }
+
+    public static RelayLobbyMessage streamClose(String roomId, String streamId, String reason) {
+        return new RelayLobbyMessage("stream_close", roomId, null, null, null, -1, -1,
+                null, null, null, streamId, reason);
     }
 
     public String type() {
@@ -98,6 +140,21 @@ public final class RelayLobbyMessage {
         }
         if (maxPlayers >= 0) {
             json.addProperty("maxPlayers", maxPlayers);
+        }
+        if (guestPlayerName != null) {
+            json.addProperty("guestPlayerName", guestPlayerName);
+        }
+        if (guestUuid != null) {
+            json.addProperty("guestUuid", guestUuid);
+        }
+        if (guestSessionId != null) {
+            json.addProperty("guestSessionId", guestSessionId);
+        }
+        if (streamId != null) {
+            json.addProperty("streamId", streamId);
+        }
+        if (reason != null) {
+            json.addProperty("reason", reason);
         }
         json.addProperty("modVersion", modVersion);
         json.addProperty("minecraftVersion", minecraftVersion);

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyRoom.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyRoom.java
@@ -1,0 +1,78 @@
+package firefly520.fireflymc.client.relay;
+
+import com.google.gson.annotations.SerializedName;
+
+/**
+ * 公开大厅房间条目。
+ */
+public class RelayLobbyRoom {
+    @SerializedName("roomId")
+    private String roomId;
+
+    @SerializedName("worldName")
+    private String worldName;
+
+    @SerializedName("hostPlayerName")
+    private String hostPlayerName;
+
+    @SerializedName("hostUuid")
+    private String hostUuid;
+
+    @SerializedName("currentPlayers")
+    private int currentPlayers;
+
+    @SerializedName("maxPlayers")
+    private int maxPlayers;
+
+    @SerializedName("modVersion")
+    private String modVersion;
+
+    @SerializedName("minecraftVersion")
+    private String minecraftVersion;
+
+    @SerializedName("status")
+    private String status;
+
+    @SerializedName("lastHeartbeat")
+    private double lastHeartbeat;
+
+    public String roomId() {
+        return roomId;
+    }
+
+    public String worldName() {
+        return worldName == null || worldName.isBlank() ? "未命名单人世界" : worldName;
+    }
+
+    public String hostPlayerName() {
+        return hostPlayerName == null || hostPlayerName.isBlank() ? "未知房主" : hostPlayerName;
+    }
+
+    public String hostUuid() {
+        return hostUuid;
+    }
+
+    public int currentPlayers() {
+        return currentPlayers;
+    }
+
+    public int maxPlayers() {
+        return maxPlayers;
+    }
+
+    public String modVersion() {
+        return modVersion;
+    }
+
+    public String minecraftVersion() {
+        return minecraftVersion;
+    }
+
+    public String status() {
+        return status == null ? "unknown" : status;
+    }
+
+    public double lastHeartbeat() {
+        return lastHeartbeat;
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyRoom.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyRoom.java
@@ -36,6 +36,15 @@ public class RelayLobbyRoom {
     @SerializedName("lastHeartbeat")
     private double lastHeartbeat;
 
+    @SerializedName("p2pSupported")
+    private boolean p2pSupported;
+
+    @SerializedName("p2pTransport")
+    private String p2pTransport;
+
+    @SerializedName("p2pProtocolVersion")
+    private int p2pProtocolVersion;
+
     public String roomId() {
         return roomId;
     }
@@ -74,5 +83,17 @@ public class RelayLobbyRoom {
 
     public double lastHeartbeat() {
         return lastHeartbeat;
+    }
+
+    public boolean p2pSupported() {
+        return p2pSupported;
+    }
+
+    public String p2pTransport() {
+        return p2pTransport == null ? "" : p2pTransport;
+    }
+
+    public int p2pProtocolVersion() {
+        return p2pProtocolVersion;
     }
 }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyState.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyState.java
@@ -1,0 +1,44 @@
+package firefly520.fireflymc.client.relay;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * 客户端公开大厅状态缓存。
+ */
+public final class RelayLobbyState {
+    private static final List<RelayLobbyRoom> ROOMS = new ArrayList<>();
+    private static String statusMessage = "尚未刷新";
+    private static boolean refreshing = false;
+
+    private RelayLobbyState() {
+    }
+
+    public static synchronized void setRefreshing(boolean value) {
+        refreshing = value;
+    }
+
+    public static synchronized boolean isRefreshing() {
+        return refreshing;
+    }
+
+    public static synchronized void updateRooms(List<RelayLobbyRoom> rooms) {
+        ROOMS.clear();
+        ROOMS.addAll(rooms);
+        refreshing = false;
+        statusMessage = rooms.isEmpty() ? "暂无公开单人世界" : "已加载 " + rooms.size() + " 个公开单人世界";
+    }
+
+    public static synchronized void setStatusMessage(String message) {
+        statusMessage = message;
+        refreshing = false;
+    }
+
+    public static synchronized String statusMessage() {
+        return statusMessage;
+    }
+
+    public static synchronized List<RelayLobbyRoom> rooms() {
+        return List.copyOf(ROOMS);
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.regex.Pattern;
 
 /**
  * 单人世界公开大厅 WebSocket 客户端。
@@ -25,6 +26,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public final class RelayLobbyWebSocketClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(RelayLobbyWebSocketClient.class);
     private static final RelayLobbyWebSocketClient INSTANCE = new RelayLobbyWebSocketClient();
+    private static final Pattern P2P_UDP_HOST_PATTERN = Pattern.compile("(\\\"p2pUdpHost\\\"\\s*:\\s*\\\")([^\\\"]*)(\\\")");
+    private static final Pattern P2P_CANDIDATE_ADDRESS_PATTERN = Pattern.compile("(\\\"address\\\"\\s*:\\s*\\\")([^\\\"]*)(\\\")");
 
     private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
         Thread thread = new Thread(r, "FireflyMC-Relay-Lobby");
@@ -181,7 +184,7 @@ public final class RelayLobbyWebSocketClient {
                         if (last) {
                             String json = textAccumulator.toString();
                             textAccumulator.setLength(0);
-                            LOGGER.debug("[FireflyMC] 收到公开大厅文本消息: {}", json);
+                            LOGGER.debug("[FireflyMC] 收到公开大厅文本消息: {}", sanitizeRelayJsonForLog(json));
                             handleTextMessage(json);
                         }
                         webSocket.request(1);
@@ -223,7 +226,7 @@ public final class RelayLobbyWebSocketClient {
                         fullData.get(bytes);
                         String message = new String(bytes, StandardCharsets.UTF_8);
                         if (message.startsWith("{")) {
-                            LOGGER.debug("[FireflyMC] 收到公开大厅二进制JSON消息: {}", message);
+                            LOGGER.debug("[FireflyMC] 收到公开大厅二进制JSON消息: {}", sanitizeRelayJsonForLog(message));
                             handleTextMessage(message);
                         } else {
                             handleBinaryFrame(bytes);
@@ -271,7 +274,7 @@ public final class RelayLobbyWebSocketClient {
             LOGGER.info("[FireflyMC] 已收到公开大厅房间列表: {} 个房间", result.rooms().size());
             RelayLobbyState.updateRooms(result.rooms());
         } else if (result == null) {
-            LOGGER.warn("[FireflyMC] 公开大厅消息 JSON 解析失败: {}", json);
+            LOGGER.warn("[FireflyMC] 公开大厅消息 JSON 解析失败: {}", sanitizeRelayJsonForLog(json));
         } else {
             RelayControlMessage message = RelayControlMessage.fromJson(json);
             handleControlMessage(message, json);
@@ -280,7 +283,7 @@ public final class RelayLobbyWebSocketClient {
 
     private void handleControlMessage(RelayControlMessage message, String rawJson) {
         if (message == null || message.type() == null) {
-            LOGGER.debug("[FireflyMC] 收到未处理的公开大厅消息: {}", rawJson);
+            LOGGER.debug("[FireflyMC] 收到未处理的公开大厅消息: {}", sanitizeRelayJsonForLog(rawJson));
             return;
         }
 
@@ -310,7 +313,7 @@ public final class RelayLobbyWebSocketClient {
             }
                 case "host_open_ack", "guest_joined", "p2p_offer", "p2p_answer", "p2p_candidate", "p2p_udp_observed", "p2p_ready", "p2p_failed", "relay_fallback" ->
                     P2PConnectionManager.getInstance().handleControlMessage(message);
-            default -> LOGGER.debug("[FireflyMC] 收到未处理的公开大厅消息: {}", rawJson);
+            default -> LOGGER.debug("[FireflyMC] 收到未处理的公开大厅消息: {}", sanitizeRelayJsonForLog(rawJson));
         }
     }
 
@@ -347,8 +350,16 @@ public final class RelayLobbyWebSocketClient {
         } else if ("stream_open".equals(message.type()) || "stream_close".equals(message.type()) || "guest_leave".equals(message.type())) {
             LOGGER.debug("[FireflyMC] 已发送 relay 流控制消息: {}", json);
         } else {
-            LOGGER.info("[FireflyMC] 已发送公开大厅消息: {}", json);
+            LOGGER.info("[FireflyMC] 已发送公开大厅消息: {}", sanitizeRelayJsonForLog(json));
         }
+    }
+
+    private static String sanitizeRelayJsonForLog(String json) {
+        if (json == null) {
+            return null;
+        }
+        String sanitized = P2P_UDP_HOST_PATTERN.matcher(json).replaceAll("$1<hidden>$3");
+        return P2P_CANDIDATE_ADDRESS_PATTERN.matcher(sanitized).replaceAll("$1<hidden>$3");
     }
 
     private void startHeartbeat() {

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
@@ -42,6 +42,7 @@ public final class RelayLobbyWebSocketClient {
     private RelayHostBridge hostBridge;
     private CompletableFuture<String> pendingJoin;
     private final StringBuilder textAccumulator = new StringBuilder();
+    private ByteBuffer binaryAccumulator = null;
     private long lastLobbyListRequestAt = 0L;
 
     private RelayLobbyWebSocketClient() {
@@ -133,15 +134,19 @@ public final class RelayLobbyWebSocketClient {
         });
     }
 
+    /**
+     * 异步发送二进制帧。不使用 executor 以避免阻塞单线程调度器。
+     * 二进制数据量大且频繁，不能排队到单线程 executor 中。
+     */
     public void sendBinary(ByteBuffer buffer) {
-        executor.execute(() -> {
-            try {
-                ensureConnected();
-                webSocket.sendBinary(buffer, true).join();
-            } catch (Exception e) {
-                LOGGER.debug("[FireflyMC] 发送 relay 二进制数据失败: {}", e.getMessage());
+        try {
+            if (webSocket != null && connected.get()) {
+                // 异步发送，不阻塞，不使用 executor
+                webSocket.sendBinary(buffer, true);
             }
-        });
+        } catch (Exception e) {
+            LOGGER.debug("[FireflyMC] 发送 relay 二进制数据失败: {}", e.getMessage());
+        }
     }
 
     private void ensureConnected() {
@@ -172,7 +177,7 @@ public final class RelayLobbyWebSocketClient {
                         if (last) {
                             String json = textAccumulator.toString();
                             textAccumulator.setLength(0);
-                            LOGGER.info("[FireflyMC] 收到公开大厅文本消息: {}", json);
+                            LOGGER.debug("[FireflyMC] 收到公开大厅文本消息: {}", json);
                             handleTextMessage(json);
                         }
                         webSocket.request(1);
@@ -181,19 +186,43 @@ public final class RelayLobbyWebSocketClient {
 
                     @Override
                     public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
-                        if (last) {
-                            ByteBuffer copy = data.slice();
-                            byte[] bytes = new byte[copy.remaining()];
-                            copy.get(bytes);
-                            String message = new String(bytes, StandardCharsets.UTF_8);
-                            if (message.startsWith("{")) {
-                                LOGGER.info("[FireflyMC] 收到公开大厅二进制JSON消息: {}", message);
-                                handleTextMessage(message);
-                            } else {
-                                handleBinaryFrame(bytes);
+                        ByteBuffer slice = data.slice();
+                        if (!last) {
+                            // 累积分片
+                            if (binaryAccumulator == null) {
+                                binaryAccumulator = ByteBuffer.allocate(slice.remaining() * 4);
                             }
+                            // 如果空间不够，扩容
+                            if (binaryAccumulator.remaining() < slice.remaining()) {
+                                int newCapacity = (binaryAccumulator.position() + slice.remaining()) * 2;
+                                ByteBuffer newBuf = ByteBuffer.allocate(newCapacity);
+                                binaryAccumulator.flip();
+                                newBuf.put(binaryAccumulator);
+                                binaryAccumulator = newBuf;
+                            }
+                            binaryAccumulator.put(slice);
+                            webSocket.request(1);
+                            return CompletableFuture.completedFuture(null);
+                        }
+                        // last=true: 合并累积数据（如果有）
+                        ByteBuffer fullData;
+                        if (binaryAccumulator != null && binaryAccumulator.position() > 0) {
+                            binaryAccumulator.put(slice);
+                            binaryAccumulator.flip();
+                            fullData = binaryAccumulator;
+                            binaryAccumulator = null;
                         } else {
-                            LOGGER.debug("[FireflyMC] 收到公开大厅二进制分片，等待后续阶段处理");
+                            fullData = slice;
+                            binaryAccumulator = null;
+                        }
+                        byte[] bytes = new byte[fullData.remaining()];
+                        fullData.get(bytes);
+                        String message = new String(bytes, StandardCharsets.UTF_8);
+                        if (message.startsWith("{")) {
+                            LOGGER.debug("[FireflyMC] 收到公开大厅二进制JSON消息: {}", message);
+                            handleTextMessage(message);
+                        } else {
+                            handleBinaryFrame(bytes);
                         }
                         webSocket.request(1);
                         return CompletableFuture.completedFuture(null);
@@ -247,7 +276,7 @@ public final class RelayLobbyWebSocketClient {
 
     private void handleControlMessage(RelayControlMessage message, String rawJson) {
         if (message == null || message.type() == null) {
-            LOGGER.info("[FireflyMC] 收到未处理的公开大厅消息: {}", rawJson);
+            LOGGER.debug("[FireflyMC] 收到未处理的公开大厅消息: {}", rawJson);
             return;
         }
 
@@ -275,7 +304,7 @@ public final class RelayLobbyWebSocketClient {
                 }
                 RelayLobbyState.setStatusMessage("Relay 错误: " + message.message());
             }
-            default -> LOGGER.info("[FireflyMC] 收到未处理的公开大厅消息: {}", rawJson);
+            default -> LOGGER.debug("[FireflyMC] 收到未处理的公开大厅消息: {}", rawJson);
         }
     }
 
@@ -309,6 +338,8 @@ public final class RelayLobbyWebSocketClient {
         webSocket.sendText(json, true).join();
         if ("heartbeat".equals(message.type())) {
             LOGGER.debug("[FireflyMC] 已发送公开大厅心跳: {}", json);
+        } else if ("stream_open".equals(message.type()) || "stream_close".equals(message.type())) {
+            LOGGER.debug("[FireflyMC] 已发送 relay 流控制消息: {}", json);
         } else {
             LOGGER.info("[FireflyMC] 已发送公开大厅消息: {}", json);
         }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
@@ -1,0 +1,235 @@
+package firefly520.fireflymc.client.relay;
+
+import firefly520.fireflymc.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.WebSocket;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * 单人世界公开大厅 WebSocket 客户端。
+ *
+ * 当前阶段只负责 host_open / host_close / heartbeat 控制消息；
+ * 真实 Minecraft 字节流转发将在后续阶段接入。
+ */
+public final class RelayLobbyWebSocketClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RelayLobbyWebSocketClient.class);
+    private static final RelayLobbyWebSocketClient INSTANCE = new RelayLobbyWebSocketClient();
+
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread thread = new Thread(r, "FireflyMC-Relay-Lobby");
+        thread.setDaemon(true);
+        return thread;
+    });
+
+    private final AtomicBoolean connected = new AtomicBoolean(false);
+    private WebSocket webSocket;
+    private ScheduledFuture<?> heartbeatTask;
+    private String currentRoomId;
+    private final StringBuilder textAccumulator = new StringBuilder();
+
+    private RelayLobbyWebSocketClient() {
+    }
+
+    public static RelayLobbyWebSocketClient getInstance() {
+        return INSTANCE;
+    }
+
+    public void publishRoom(RelayLobbyMessage message, String roomId) {
+        this.currentRoomId = roomId;
+        executor.execute(() -> {
+            try {
+                ensureConnected();
+                send(message);
+                startHeartbeat();
+            } catch (Exception e) {
+                LOGGER.warn("[FireflyMC] 发布单人世界公开房间失败: {}", e.getMessage());
+            }
+        });
+    }
+
+    public void closeRoom() {
+        String roomId = currentRoomId;
+        executor.execute(() -> {
+            stopHeartbeat();
+            if (roomId != null && webSocket != null && connected.get()) {
+                try {
+                    send(RelayLobbyMessage.hostClose(roomId));
+                } catch (Exception e) {
+                    LOGGER.debug("[FireflyMC] 发送关闭公开房间消息失败: {}", e.getMessage());
+                }
+            }
+            currentRoomId = null;
+        });
+    }
+
+    public void requestLobbyList() {
+        RelayLobbyState.setRefreshing(true);
+        executor.execute(() -> {
+            try {
+                ensureConnected();
+                LOGGER.info("[FireflyMC] 正在请求公开大厅房间列表");
+                send(RelayLobbyMessage.lobbyList());
+                scheduleLobbyListTimeout();
+            } catch (Exception e) {
+                RelayLobbyState.setStatusMessage("刷新失败: " + e.getMessage());
+                LOGGER.warn("[FireflyMC] 请求公开大厅列表失败: {}", e.getMessage());
+            }
+        });
+    }
+
+    private void ensureConnected() {
+        if (webSocket != null && connected.get()) {
+            return;
+        }
+
+        URI uri = URI.create(Config.CLIENT.SINGLEPLAYER_RELAY_URL.get());
+        LOGGER.info("[FireflyMC] 正在连接单人世界公开大厅: {}", uri);
+
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        CompletableFuture<WebSocket> connectFuture = client.newWebSocketBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .buildAsync(uri, new WebSocket.Listener() {
+                    @Override
+                    public void onOpen(WebSocket webSocket) {
+                        connected.set(true);
+                        LOGGER.info("[FireflyMC] 单人世界公开大厅连接成功");
+                        webSocket.request(1);
+                    }
+
+                    @Override
+                    public CompletionStage<?> onText(WebSocket webSocket, CharSequence data, boolean last) {
+                        textAccumulator.append(data);
+                        if (last) {
+                            String json = textAccumulator.toString();
+                            textAccumulator.setLength(0);
+                            LOGGER.info("[FireflyMC] 收到公开大厅文本消息: {}", json);
+                            handleTextMessage(json);
+                        }
+                        webSocket.request(1);
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    @Override
+                    public CompletionStage<?> onBinary(WebSocket webSocket, ByteBuffer data, boolean last) {
+                        if (last) {
+                            ByteBuffer copy = data.slice();
+                            byte[] bytes = new byte[copy.remaining()];
+                            copy.get(bytes);
+                            String message = new String(bytes, StandardCharsets.UTF_8);
+                            if (message.startsWith("{")) {
+                                LOGGER.info("[FireflyMC] 收到公开大厅二进制JSON消息: {}", message);
+                                handleTextMessage(message);
+                            } else {
+                                LOGGER.debug("[FireflyMC] 收到公开大厅二进制消息: {} bytes", bytes.length);
+                            }
+                        } else {
+                            LOGGER.debug("[FireflyMC] 收到公开大厅二进制分片，等待后续阶段处理");
+                        }
+                        webSocket.request(1);
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    @Override
+                    public CompletionStage<?> onClose(WebSocket webSocket, int statusCode, String reason) {
+                        connected.set(false);
+                        LOGGER.info("[FireflyMC] 单人世界公开大厅连接关闭: {} - {}", statusCode, reason);
+                        return CompletableFuture.completedFuture(null);
+                    }
+
+                    @Override
+                    public void onError(WebSocket webSocket, Throwable error) {
+                        connected.set(false);
+                        LOGGER.warn("[FireflyMC] 单人世界公开大厅连接错误: {}", error.getMessage());
+                    }
+                });
+
+        webSocket = connectFuture.join();
+        waitUntilOpen();
+    }
+
+    private void waitUntilOpen() {
+        long deadline = System.currentTimeMillis() + 5000;
+        while (!connected.get() && System.currentTimeMillis() < deadline) {
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        if (!connected.get()) {
+            throw new IllegalStateException("Relay lobby WebSocket open timeout");
+        }
+    }
+
+    private void handleTextMessage(String json) {
+        RelayLobbyListResult result = RelayLobbyListResult.fromJson(json);
+        if (result != null && result.isLobbyListResult()) {
+            LOGGER.info("[FireflyMC] 已收到公开大厅房间列表: {} 个房间", result.rooms().size());
+            RelayLobbyState.updateRooms(result.rooms());
+        } else if (result == null) {
+            LOGGER.warn("[FireflyMC] 公开大厅消息 JSON 解析失败: {}", json);
+        } else {
+            LOGGER.info("[FireflyMC] 收到未处理的公开大厅消息: {}", json);
+        }
+    }
+
+    private void scheduleLobbyListTimeout() {
+        executor.schedule(() -> {
+            if (RelayLobbyState.isRefreshing()) {
+                RelayLobbyState.setStatusMessage("公开大厅暂无响应，请稍后重试");
+                LOGGER.warn("[FireflyMC] 公开大厅列表请求超时");
+            }
+        }, 8, TimeUnit.SECONDS);
+    }
+
+    private void send(RelayLobbyMessage message) {
+        if (webSocket == null || !connected.get()) {
+            throw new IllegalStateException("Relay lobby WebSocket is not connected");
+        }
+        String json = message.toJson();
+        webSocket.sendText(json, true).join();
+        if ("heartbeat".equals(message.type())) {
+            LOGGER.debug("[FireflyMC] 已发送公开大厅心跳: {}", json);
+        } else {
+            LOGGER.info("[FireflyMC] 已发送公开大厅消息: {}", json);
+        }
+    }
+
+    private void startHeartbeat() {
+        stopHeartbeat();
+        heartbeatTask = executor.scheduleAtFixedRate(() -> {
+            if (currentRoomId == null || webSocket == null || !connected.get()) {
+                return;
+            }
+            try {
+                send(RelayLobbyMessage.heartbeat(currentRoomId));
+            } catch (Exception e) {
+                LOGGER.debug("[FireflyMC] 发送公开大厅心跳失败: {}", e.getMessage());
+            }
+        }, 30, 30, TimeUnit.SECONDS);
+    }
+
+    private void stopHeartbeat() {
+        if (heartbeatTask != null && !heartbeatTask.isDone()) {
+            heartbeatTask.cancel(false);
+        }
+        heartbeatTask = null;
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
@@ -346,9 +346,9 @@ public final class RelayLobbyWebSocketClient {
         String json = message.toJson();
         webSocket.sendText(json, true).join();
         if ("heartbeat".equals(message.type())) {
-            LOGGER.debug("[FireflyMC] 已发送公开大厅心跳: {}", json);
+            LOGGER.debug("[FireflyMC] 已发送公开大厅心跳: {}", sanitizeRelayJsonForLog(json));
         } else if ("stream_open".equals(message.type()) || "stream_close".equals(message.type()) || "guest_leave".equals(message.type())) {
-            LOGGER.debug("[FireflyMC] 已发送 relay 流控制消息: {}", json);
+            LOGGER.debug("[FireflyMC] 已发送 relay 流控制消息: {}", sanitizeRelayJsonForLog(json));
         } else {
             LOGGER.info("[FireflyMC] 已发送公开大厅消息: {}", sanitizeRelayJsonForLog(json));
         }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
@@ -20,9 +20,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * 单人世界公开大厅 WebSocket 客户端。
- *
- * 当前阶段只负责 host_open / host_close / heartbeat 控制消息；
- * 真实 Minecraft 字节流转发将在后续阶段接入。
  */
 public final class RelayLobbyWebSocketClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(RelayLobbyWebSocketClient.class);
@@ -121,6 +118,12 @@ public final class RelayLobbyWebSocketClient {
 
     public void setGuestProxy(RelayGuestProxy proxy) {
         this.guestProxy = proxy;
+    }
+
+    public void clearGuestProxy(RelayGuestProxy proxy) {
+        if (this.guestProxy == proxy) {
+            this.guestProxy = null;
+        }
     }
 
     public void sendControl(RelayLobbyMessage message) {
@@ -338,7 +341,7 @@ public final class RelayLobbyWebSocketClient {
         webSocket.sendText(json, true).join();
         if ("heartbeat".equals(message.type())) {
             LOGGER.debug("[FireflyMC] 已发送公开大厅心跳: {}", json);
-        } else if ("stream_open".equals(message.type()) || "stream_close".equals(message.type())) {
+        } else if ("stream_open".equals(message.type()) || "stream_close".equals(message.type()) || "guest_leave".equals(message.type())) {
             LOGGER.debug("[FireflyMC] 已发送 relay 流控制消息: {}", json);
         } else {
             LOGGER.info("[FireflyMC] 已发送公开大厅消息: {}", json);

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
@@ -1,6 +1,7 @@
 package firefly520.fireflymc.client.relay;
 
 import firefly520.fireflymc.Config;
+import firefly520.fireflymc.client.relay.p2p.P2PConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,7 +38,7 @@ public final class RelayLobbyWebSocketClient {
     private String currentRoomId;
     private RelayGuestProxy guestProxy;
     private RelayHostBridge hostBridge;
-    private CompletableFuture<String> pendingJoin;
+    private CompletableFuture<RelayControlMessage> pendingJoin;
     private final StringBuilder textAccumulator = new StringBuilder();
     private ByteBuffer binaryAccumulator = null;
     private long lastLobbyListRequestAt = 0L;
@@ -102,8 +103,8 @@ public final class RelayLobbyWebSocketClient {
         });
     }
 
-    public CompletableFuture<String> joinRoom(RelayLobbyRoom room, String guestPlayerName, String guestUuid) {
-        CompletableFuture<String> future = new CompletableFuture<>();
+    public CompletableFuture<RelayControlMessage> joinRoom(RelayLobbyRoom room, String guestPlayerName, String guestUuid) {
+        CompletableFuture<RelayControlMessage> future = new CompletableFuture<>();
         pendingJoin = future;
         executor.execute(() -> {
             try {
@@ -286,7 +287,7 @@ public final class RelayLobbyWebSocketClient {
         switch (message.type()) {
             case "join_accepted" -> {
                 if (pendingJoin != null) {
-                    pendingJoin.complete(message.guestSessionId());
+                    pendingJoin.complete(message);
                     pendingJoin = null;
                 }
             }
@@ -307,6 +308,8 @@ public final class RelayLobbyWebSocketClient {
                 }
                 RelayLobbyState.setStatusMessage("Relay 错误: " + message.message());
             }
+            case "p2p_offer", "p2p_answer", "p2p_candidate", "p2p_udp_observed", "p2p_ready", "p2p_failed", "relay_fallback" ->
+                    P2PConnectionManager.getInstance().handleControlMessage(message);
             default -> LOGGER.debug("[FireflyMC] 收到未处理的公开大厅消息: {}", rawJson);
         }
     }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
@@ -38,6 +38,9 @@ public final class RelayLobbyWebSocketClient {
     private WebSocket webSocket;
     private ScheduledFuture<?> heartbeatTask;
     private String currentRoomId;
+    private RelayGuestProxy guestProxy;
+    private RelayHostBridge hostBridge;
+    private CompletableFuture<String> pendingJoin;
     private final StringBuilder textAccumulator = new StringBuilder();
 
     private RelayLobbyWebSocketClient() {
@@ -58,6 +61,10 @@ public final class RelayLobbyWebSocketClient {
                 LOGGER.warn("[FireflyMC] 发布单人世界公开房间失败: {}", e.getMessage());
             }
         });
+    }
+
+    public void setHostBridge(RelayHostBridge hostBridge) {
+        this.hostBridge = hostBridge;
     }
 
     public void closeRoom() {
@@ -86,6 +93,46 @@ public final class RelayLobbyWebSocketClient {
             } catch (Exception e) {
                 RelayLobbyState.setStatusMessage("刷新失败: " + e.getMessage());
                 LOGGER.warn("[FireflyMC] 请求公开大厅列表失败: {}", e.getMessage());
+            }
+        });
+    }
+
+    public CompletableFuture<String> joinRoom(RelayLobbyRoom room, String guestPlayerName, String guestUuid) {
+        CompletableFuture<String> future = new CompletableFuture<>();
+        pendingJoin = future;
+        executor.execute(() -> {
+            try {
+                ensureConnected();
+                send(RelayLobbyMessage.guestJoin(room.roomId(), guestPlayerName, guestUuid));
+            } catch (Exception e) {
+                future.completeExceptionally(e);
+            }
+        });
+        return future;
+    }
+
+    public void setGuestProxy(RelayGuestProxy proxy) {
+        this.guestProxy = proxy;
+    }
+
+    public void sendControl(RelayLobbyMessage message) {
+        executor.execute(() -> {
+            try {
+                ensureConnected();
+                send(message);
+            } catch (Exception e) {
+                LOGGER.debug("[FireflyMC] 发送 relay 控制消息失败: {}", e.getMessage());
+            }
+        });
+    }
+
+    public void sendBinary(ByteBuffer buffer) {
+        executor.execute(() -> {
+            try {
+                ensureConnected();
+                webSocket.sendBinary(buffer, true).join();
+            } catch (Exception e) {
+                LOGGER.debug("[FireflyMC] 发送 relay 二进制数据失败: {}", e.getMessage());
             }
         });
     }
@@ -136,7 +183,7 @@ public final class RelayLobbyWebSocketClient {
                                 LOGGER.info("[FireflyMC] 收到公开大厅二进制JSON消息: {}", message);
                                 handleTextMessage(message);
                             } else {
-                                LOGGER.debug("[FireflyMC] 收到公开大厅二进制消息: {} bytes", bytes.length);
+                                handleBinaryFrame(bytes);
                             }
                         } else {
                             LOGGER.debug("[FireflyMC] 收到公开大厅二进制分片，等待后续阶段处理");
@@ -186,7 +233,55 @@ public final class RelayLobbyWebSocketClient {
         } else if (result == null) {
             LOGGER.warn("[FireflyMC] 公开大厅消息 JSON 解析失败: {}", json);
         } else {
-            LOGGER.info("[FireflyMC] 收到未处理的公开大厅消息: {}", json);
+            RelayControlMessage message = RelayControlMessage.fromJson(json);
+            handleControlMessage(message, json);
+        }
+    }
+
+    private void handleControlMessage(RelayControlMessage message, String rawJson) {
+        if (message == null || message.type() == null) {
+            LOGGER.info("[FireflyMC] 收到未处理的公开大厅消息: {}", rawJson);
+            return;
+        }
+
+        switch (message.type()) {
+            case "join_accepted" -> {
+                if (pendingJoin != null) {
+                    pendingJoin.complete(message.guestSessionId());
+                    pendingJoin = null;
+                }
+            }
+            case "stream_open" -> {
+                if (hostBridge != null && message.streamId() != null) {
+                    hostBridge.openStream(message.streamId());
+                }
+            }
+            case "stream_close" -> {
+                if (hostBridge != null && message.streamId() != null) {
+                    hostBridge.closeStream(message.streamId(), "remote_closed");
+                }
+            }
+            case "error" -> {
+                if (pendingJoin != null) {
+                    pendingJoin.completeExceptionally(new IllegalStateException(message.code() + ": " + message.message()));
+                    pendingJoin = null;
+                }
+                RelayLobbyState.setStatusMessage("Relay 错误: " + message.message());
+            }
+            default -> LOGGER.info("[FireflyMC] 收到未处理的公开大厅消息: {}", rawJson);
+        }
+    }
+
+    private void handleBinaryFrame(byte[] bytes) {
+        boolean handled = false;
+        if (guestProxy != null) {
+            handled = guestProxy.handleBinary(bytes);
+        }
+        if (!handled && hostBridge != null) {
+            handled = hostBridge.handleBinary(bytes);
+        }
+        if (!handled) {
+            LOGGER.debug("[FireflyMC] 收到未路由的 relay 二进制消息: {} bytes", bytes.length);
         }
     }
 

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
@@ -42,6 +42,7 @@ public final class RelayLobbyWebSocketClient {
     private RelayHostBridge hostBridge;
     private CompletableFuture<String> pendingJoin;
     private final StringBuilder textAccumulator = new StringBuilder();
+    private long lastLobbyListRequestAt = 0L;
 
     private RelayLobbyWebSocketClient() {
     }
@@ -83,6 +84,12 @@ public final class RelayLobbyWebSocketClient {
     }
 
     public void requestLobbyList() {
+        long now = System.currentTimeMillis();
+        if (RelayLobbyState.isRefreshing() || now - lastLobbyListRequestAt < 1000) {
+            LOGGER.debug("[FireflyMC] 跳过重复公开大厅刷新请求");
+            return;
+        }
+        lastLobbyListRequestAt = now;
         RelayLobbyState.setRefreshing(true);
         executor.execute(() -> {
             try {

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyWebSocketClient.java
@@ -308,7 +308,7 @@ public final class RelayLobbyWebSocketClient {
                 }
                 RelayLobbyState.setStatusMessage("Relay 错误: " + message.message());
             }
-            case "p2p_offer", "p2p_answer", "p2p_candidate", "p2p_udp_observed", "p2p_ready", "p2p_failed", "relay_fallback" ->
+                case "host_open_ack", "guest_joined", "p2p_offer", "p2p_answer", "p2p_candidate", "p2p_udp_observed", "p2p_ready", "p2p_failed", "relay_fallback" ->
                     P2PConnectionManager.getInstance().handleControlMessage(message);
             default -> LOGGER.debug("[FireflyMC] 收到未处理的公开大厅消息: {}", rawJson);
         }

--- a/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayClientEvents.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayClientEvents.java
@@ -1,0 +1,84 @@
+package firefly520.fireflymc.client.relay;
+
+import firefly520.fireflymc.Config;
+import firefly520.fireflymc.client.ClientState;
+import firefly520.fireflymc.client.screen.RelayLobbyScreen;
+import firefly520.fireflymc.client.screen.SingleplayerSharePromptScreen;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
+import net.minecraft.client.server.IntegratedServer;
+import net.neoforged.neoforge.client.event.ClientPlayerNetworkEvent;
+import net.neoforged.neoforge.client.event.ClientTickEvent;
+import net.neoforged.neoforge.client.event.ScreenEvent;
+import net.minecraft.network.chat.Component;
+
+/**
+ * 单人世界联机阶段一客户端事件。
+ */
+public final class SingleplayerRelayClientEvents {
+    private static boolean promptPending = false;
+
+    private SingleplayerRelayClientEvents() {
+    }
+
+    public static void onClientLoggedIn(ClientPlayerNetworkEvent.LoggingIn event) {
+        Minecraft mc = Minecraft.getInstance();
+        if (!Config.CLIENT.SINGLEPLAYER_RELAY_ENABLED.get() || !Config.CLIENT.SINGLEPLAYER_RELAY_PROMPT_ON_JOIN.get()) {
+            return;
+        }
+
+        if (mc.getSingleplayerServer() != null) {
+            ClientState.hasHandledSingleplayerRelayPrompt = false;
+            promptPending = true;
+        }
+    }
+
+    public static void onClientLoggedOut(ClientPlayerNetworkEvent.LoggingOut event) {
+        promptPending = false;
+        ClientState.hasHandledSingleplayerRelayPrompt = false;
+        SingleplayerRelayManager.getInstance().stopHosting();
+    }
+
+    public static void onClientTick(ClientTickEvent.Post event) {
+        if (!promptPending || ClientState.hasHandledSingleplayerRelayPrompt) {
+            return;
+        }
+
+        Minecraft mc = Minecraft.getInstance();
+        IntegratedServer server = mc.getSingleplayerServer();
+        if (server == null || mc.player == null || mc.level == null || mc.screen != null) {
+            return;
+        }
+
+        promptPending = false;
+        mc.setScreen(new SingleplayerSharePromptScreen(null, resolveWorldName(server)));
+    }
+
+    public static void onScreenInit(ScreenEvent.Init.Post event) {
+        if (!(event.getScreen() instanceof JoinMultiplayerScreen screen)) {
+            return;
+        }
+
+        int buttonWidth = 120;
+        int buttonHeight = 20;
+        int x = screen.width - buttonWidth - 8;
+        int y = 8;
+        event.addListener(Button.builder(
+                Component.literal("FireflyMC 联机大厅"),
+                button -> Minecraft.getInstance().setScreen(new RelayLobbyScreen(screen))
+        ).bounds(x, y, buttonWidth, buttonHeight).build());
+    }
+
+    private static String resolveWorldName(IntegratedServer server) {
+        try {
+            String name = server.getWorldData().getLevelName();
+            if (name != null && !name.isBlank()) {
+                return name;
+            }
+        } catch (Exception ignored) {
+            // 使用降级名称
+        }
+        return "我的单人世界";
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayClientEvents.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayClientEvents.java
@@ -14,7 +14,7 @@ import net.neoforged.neoforge.client.event.ScreenEvent;
 import net.minecraft.network.chat.Component;
 
 /**
- * 单人世界联机阶段一客户端事件。
+ * 单人世界公开联机客户端事件。
  */
 public final class SingleplayerRelayClientEvents {
     private static boolean promptPending = false;
@@ -37,6 +37,7 @@ public final class SingleplayerRelayClientEvents {
     public static void onClientLoggedOut(ClientPlayerNetworkEvent.LoggingOut event) {
         promptPending = false;
         ClientState.hasHandledSingleplayerRelayPrompt = false;
+        RelayGuestJoiner.stopActiveRelay("client_logged_out");
         SingleplayerRelayManager.getInstance().stopHosting();
     }
 

--- a/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
@@ -106,14 +106,24 @@ public final class SingleplayerRelayManager {
         String playerUuid = mc.getUser().getProfileId().toString();
         int maxPlayers = Config.CLIENT.SINGLEPLAYER_RELAY_MAX_PLAYERS.get();
 
-        RelayLobbyMessage message = RelayLobbyMessage.hostOpen(
+        RelayLobbyMessage message = Config.CLIENT.SINGLEPLAYER_RELAY_P2P_ENABLED.get()
+            ? RelayLobbyMessage.hostOpenP2P(
+                currentRoomId,
+                worldName,
+                playerName,
+                playerUuid,
+                port,
+                maxPlayers,
+                currentRoomId
+            )
+            : RelayLobbyMessage.hostOpen(
                 currentRoomId,
                 worldName,
                 playerName,
                 playerUuid,
                 port,
                 maxPlayers
-        );
+            );
             if (hostBridge != null) {
                 hostBridge.stop();
             }

--- a/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
@@ -21,6 +21,7 @@ public final class SingleplayerRelayManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(SingleplayerRelayManager.class);
     private static final SingleplayerRelayManager INSTANCE = new SingleplayerRelayManager();
     private String currentRoomId;
+    private RelayHostBridge hostBridge;
 
     private SingleplayerRelayManager() {
     }
@@ -85,6 +86,11 @@ public final class SingleplayerRelayManager {
             LOGGER.info("[FireflyMC] 停止单人世界联机准备状态");
         }
         RelayLobbyWebSocketClient.getInstance().closeRoom();
+        if (hostBridge != null) {
+            hostBridge.stop();
+            hostBridge = null;
+        }
+        RelayLobbyWebSocketClient.getInstance().setHostBridge(null);
         currentRoomId = null;
         ClientState.isSingleplayerRelayHosting = false;
         ClientState.singleplayerRelayLanPort = -1;
@@ -108,6 +114,11 @@ public final class SingleplayerRelayManager {
                 port,
                 maxPlayers
         );
+            if (hostBridge != null) {
+                hostBridge.stop();
+            }
+            hostBridge = new RelayHostBridge(port);
+            RelayLobbyWebSocketClient.getInstance().setHostBridge(hostBridge);
         RelayLobbyWebSocketClient.getInstance().publishRoom(message, currentRoomId);
         LOGGER.info("[FireflyMC] 已准备发布公开房间: roomId={}, worldName={}, maxPlayers={}",
                 currentRoomId, worldName, maxPlayers);

--- a/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
@@ -1,0 +1,134 @@
+package firefly520.fireflymc.client.relay;
+
+import firefly520.fireflymc.Config;
+import firefly520.fireflymc.client.ClientState;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.server.IntegratedServer;
+import net.minecraft.world.level.GameType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.UUID;
+
+/**
+ * 阶段一：单人世界联机的 LAN 暴露准备。
+ *
+ * 后续阶段会在获取到 LAN 端口后接入 WebSocket 中继和公开大厅。
+ */
+public final class SingleplayerRelayManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SingleplayerRelayManager.class);
+    private static final SingleplayerRelayManager INSTANCE = new SingleplayerRelayManager();
+    private String currentRoomId;
+
+    private SingleplayerRelayManager() {
+    }
+
+    public static SingleplayerRelayManager getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * 开始为当前单人世界做 LAN 暴露准备。
+     * 必须在客户端主线程调用。
+     */
+    public void startHosting() {
+        Minecraft mc = Minecraft.getInstance();
+        if (!mc.isSameThread()) {
+            mc.execute(this::startHosting);
+            return;
+        }
+
+        if (!Config.CLIENT.SINGLEPLAYER_RELAY_ENABLED.get()) {
+            LOGGER.info("[FireflyMC] 单人世界联机功能未启用");
+            return;
+        }
+
+        IntegratedServer server = mc.getSingleplayerServer();
+        if (server == null) {
+            LOGGER.warn("[FireflyMC] 当前不在单人世界，无法开启联机");
+            return;
+        }
+
+        try {
+            if (!server.isPublished()) {
+                boolean allowCommands = Config.CLIENT.SINGLEPLAYER_RELAY_ALLOW_COMMANDS.get();
+                int requestedPort = findAvailablePort();
+                boolean published = server.publishServer(GameType.SURVIVAL, allowCommands, requestedPort);
+                LOGGER.info("[FireflyMC] 单人世界开放 LAN 结果: {}, requestedPort={}, allowCommands={}",
+                        published, requestedPort, allowCommands);
+            }
+
+            int port = server.getPort();
+            ClientState.isSingleplayerRelayHosting = true;
+            ClientState.singleplayerRelayLanPort = port;
+
+            if (port > 0) {
+                LOGGER.info("[FireflyMC] 单人世界 LAN 端口已准备: {}", port);
+                publishLobbyRoom(mc, server, port);
+            } else {
+                LOGGER.warn("[FireflyMC] 单人世界已开放 LAN，但暂未能读取监听端口");
+            }
+        } catch (Exception e) {
+            ClientState.isSingleplayerRelayHosting = false;
+            ClientState.singleplayerRelayLanPort = -1;
+            LOGGER.error("[FireflyMC] 开启单人世界联机准备失败", e);
+        }
+    }
+
+    /**
+     * 阶段一仅清理本模组状态。原版 LAN 监听会随 IntegratedServer 退出自动关闭。
+     */
+    public void stopHosting() {
+        if (ClientState.isSingleplayerRelayHosting || ClientState.singleplayerRelayLanPort > 0) {
+            LOGGER.info("[FireflyMC] 停止单人世界联机准备状态");
+        }
+        RelayLobbyWebSocketClient.getInstance().closeRoom();
+        currentRoomId = null;
+        ClientState.isSingleplayerRelayHosting = false;
+        ClientState.singleplayerRelayLanPort = -1;
+    }
+
+    private void publishLobbyRoom(Minecraft mc, IntegratedServer server, int port) {
+        if (currentRoomId == null) {
+            currentRoomId = UUID.randomUUID().toString();
+        }
+
+        String worldName = resolveWorldName(server);
+        String playerName = mc.getUser().getName();
+        String playerUuid = mc.getUser().getProfileId().toString();
+        int maxPlayers = Config.CLIENT.SINGLEPLAYER_RELAY_MAX_PLAYERS.get();
+
+        RelayLobbyMessage message = RelayLobbyMessage.hostOpen(
+                currentRoomId,
+                worldName,
+                playerName,
+                playerUuid,
+                port,
+                maxPlayers
+        );
+        RelayLobbyWebSocketClient.getInstance().publishRoom(message, currentRoomId);
+        LOGGER.info("[FireflyMC] 已准备发布公开房间: roomId={}, worldName={}, maxPlayers={}",
+                currentRoomId, worldName, maxPlayers);
+    }
+
+    private String resolveWorldName(IntegratedServer server) {
+        try {
+            String name = server.getWorldData().getLevelName();
+            if (name != null && !name.isBlank()) {
+                return name;
+            }
+        } catch (Exception ignored) {
+            // 使用降级名称
+        }
+        return "我的单人世界";
+    }
+
+    private int findAvailablePort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            socket.setReuseAddress(true);
+            return socket.getLocalPort();
+        }
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
@@ -2,6 +2,7 @@ package firefly520.fireflymc.client.relay;
 
 import firefly520.fireflymc.Config;
 import firefly520.fireflymc.client.ClientState;
+import firefly520.fireflymc.client.relay.p2p.P2PConnectionManager;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.server.IntegratedServer;
 import net.minecraft.world.level.GameType;
@@ -86,6 +87,7 @@ public final class SingleplayerRelayManager {
             LOGGER.info("[FireflyMC] 停止单人世界公开联机状态");
         }
         RelayLobbyWebSocketClient.getInstance().closeRoom();
+        P2PConnectionManager.getInstance().stopHost();
         if (hostBridge != null) {
             hostBridge.stop();
             hostBridge = null;
@@ -129,6 +131,7 @@ public final class SingleplayerRelayManager {
             }
             hostBridge = new RelayHostBridge(port);
             RelayLobbyWebSocketClient.getInstance().setHostBridge(hostBridge);
+            P2PConnectionManager.getInstance().prepareHost(currentRoomId, port);
         RelayLobbyWebSocketClient.getInstance().publishRoom(message, currentRoomId);
         LOGGER.info("[FireflyMC] 已准备发布公开房间: roomId={}, worldName={}, maxPlayers={}",
                 currentRoomId, worldName, maxPlayers);

--- a/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
@@ -57,8 +57,13 @@ public final class SingleplayerRelayManager {
                 boolean allowCommands = Config.CLIENT.SINGLEPLAYER_RELAY_ALLOW_COMMANDS.get();
                 int requestedPort = findAvailablePort();
                 boolean published = server.publishServer(GameType.SURVIVAL, allowCommands, requestedPort);
+                server.setUsesAuthentication(false);
+                server.setPreventProxyConnections(false);
                 LOGGER.info("[FireflyMC] 单人世界开放 LAN 结果: {}, requestedPort={}, allowCommands={}",
                         published, requestedPort, allowCommands);
+            } else {
+                server.setUsesAuthentication(false);
+                server.setPreventProxyConnections(false);
             }
 
             int port = server.getPort();

--- a/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/SingleplayerRelayManager.java
@@ -13,9 +13,7 @@ import java.net.ServerSocket;
 import java.util.UUID;
 
 /**
- * 阶段一：单人世界联机的 LAN 暴露准备。
- *
- * 后续阶段会在获取到 LAN 端口后接入 WebSocket 中继和公开大厅。
+ * 单人世界公开大厅发布与中继桥接管理。
  */
 public final class SingleplayerRelayManager {
     private static final Logger LOGGER = LoggerFactory.getLogger(SingleplayerRelayManager.class);
@@ -31,7 +29,7 @@ public final class SingleplayerRelayManager {
     }
 
     /**
-     * 开始为当前单人世界做 LAN 暴露准备。
+        * 开始将当前单人世界发布到 FireflyMC 联机大厅。
      * 必须在客户端主线程调用。
      */
     public void startHosting() {
@@ -83,12 +81,9 @@ public final class SingleplayerRelayManager {
         }
     }
 
-    /**
-     * 阶段一仅清理本模组状态。原版 LAN 监听会随 IntegratedServer 退出自动关闭。
-     */
     public void stopHosting() {
         if (ClientState.isSingleplayerRelayHosting || ClientState.singleplayerRelayLanPort > 0) {
-            LOGGER.info("[FireflyMC] 停止单人世界联机准备状态");
+            LOGGER.info("[FireflyMC] 停止单人世界公开联机状态");
         }
         RelayLobbyWebSocketClient.getInstance().closeRoom();
         if (hostBridge != null) {

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PCandidate.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PCandidate.java
@@ -1,0 +1,13 @@
+package firefly520.fireflymc.client.relay.p2p;
+
+import java.net.InetSocketAddress;
+
+public record P2PCandidate(String address, int port) {
+    public boolean isValid() {
+        return address != null && !address.isBlank() && port > 0 && port <= 65535;
+    }
+
+    public InetSocketAddress toSocketAddress() {
+        return new InetSocketAddress(address, port);
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
@@ -116,7 +116,7 @@ public final class P2PConnectionManager {
             hostUdpPort = message.p2pUdpPort();
             startHostProbeIfReady();
         } else if ("p2p_ready".equals(message.type())) {
-            startHostBridge();
+            startHostBridge(message.guestSessionId());
         }
     }
 
@@ -170,13 +170,16 @@ public final class P2PConnectionManager {
         }
     }
 
-    private void startHostBridge() {
-        ReliableUdpChannel channel = channels.get(hostSessionId);
-        if (channel != null && hostLanPort > 0 && !hostBridges.containsKey(hostSessionId)) {
+    private void startHostBridge(String sessionId) {
+        if (sessionId == null) {
+            sessionId = hostSessionId;
+        }
+        ReliableUdpChannel channel = channels.get(sessionId);
+        if (channel != null && hostLanPort > 0 && !hostBridges.containsKey(sessionId)) {
             P2PHostBridge hostBridge = new P2PHostBridge(hostLanPort, channel);
-            hostBridges.put(hostSessionId, hostBridge);
+            hostBridges.put(sessionId, hostBridge);
             hostBridge.startDefaultStream();
-            LOGGER.info("[FireflyMC] P2P Host bridge started for LAN port {}", hostLanPort);
+            LOGGER.info("[FireflyMC] P2P Host bridge started for LAN port {}, session={}", hostLanPort, sessionId);
         }
     }
 

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
@@ -1,0 +1,87 @@
+package firefly520.fireflymc.client.relay.p2p;
+
+import firefly520.fireflymc.client.relay.RelayControlMessage;
+import firefly520.fireflymc.client.relay.RelayLobbyMessage;
+import firefly520.fireflymc.client.relay.RelayLobbyWebSocketClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.SocketException;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Coordinates P2P attempts and keeps relay fallback decisions centralized. */
+public final class P2PConnectionManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger(P2PConnectionManager.class);
+    private static final P2PConnectionManager INSTANCE = new P2PConnectionManager();
+
+    private final Map<String, ReliableUdpChannel> channels = new ConcurrentHashMap<>();
+    private final Map<String, P2PCandidate> candidates = new ConcurrentHashMap<>();
+
+    private P2PConnectionManager() {
+    }
+
+    public static P2PConnectionManager getInstance() {
+        return INSTANCE;
+    }
+
+    public CompletableFuture<P2PResult> tryGuestConnect(P2PJoinInfo info) {
+        CompletableFuture<P2PResult> result = new CompletableFuture<>();
+        if (!info.isUsable()) {
+            LOGGER.warn("[FireflyMC] P2P join info incomplete, fallback to relay: room={}, session={}, udp={}:{}",
+                    info.roomId(), info.guestSessionId(), info.udpHost(), info.udpPort());
+            result.complete(P2PResult.failed("p2p_join_info_incomplete"));
+            return result;
+        }
+        try {
+            ReliableUdpChannel channel = new ReliableUdpChannel();
+            channels.put(info.guestSessionId(), channel);
+            RelayLobbyWebSocketClient.getInstance().sendControl(
+                    RelayLobbyMessage.p2pOffer(info.roomId(), info.guestSessionId(), info.p2pSessionId(), info.p2pToken())
+            );
+            P2PCandidate candidate = candidates.get(info.guestSessionId());
+            channel.probeAndPunch(info, candidate, "guest").whenComplete((success, error) -> {
+                if (error != null || !Boolean.TRUE.equals(success)) {
+                    RelayLobbyWebSocketClient.getInstance().sendControl(
+                            RelayLobbyMessage.relayFallback(info.roomId(), info.guestSessionId(), info.p2pSessionId(), info.p2pToken(), "p2p_timeout")
+                    );
+                    result.complete(P2PResult.failed("p2p_timeout"));
+                    return;
+                }
+                RelayLobbyWebSocketClient.getInstance().sendControl(
+                        RelayLobbyMessage.p2pReady(info.roomId(), info.guestSessionId(), info.p2pSessionId(), info.p2pToken())
+                );
+                // The reliable stream bridge is reserved for the next increment; fallback remains safe.
+                result.complete(P2PResult.failed("p2p_stream_bridge_not_ready"));
+            });
+        } catch (SocketException e) {
+            LOGGER.warn("[FireflyMC] P2P UDP channel create failed: {}", e.getMessage());
+            result.complete(P2PResult.failed("udp_socket_failed"));
+        }
+        return result;
+    }
+
+    public void handleControlMessage(RelayControlMessage message) {
+        if (message == null || message.guestSessionId() == null) {
+            return;
+        }
+        if ("p2p_udp_observed".equals(message.type()) && message.candidate() != null) {
+            RelayControlMessage.P2PCandidate raw = message.candidate();
+            P2PCandidate candidate = new P2PCandidate(raw.address(), raw.port());
+            candidates.put(message.guestSessionId(), candidate);
+            ReliableUdpChannel channel = channels.get(message.guestSessionId());
+            if (channel != null) {
+                channel.setPeerCandidate(candidate);
+            }
+        }
+    }
+
+    public void stop(String guestSessionId) {
+        ReliableUdpChannel channel = channels.remove(guestSessionId);
+        if (channel != null) {
+            channel.close();
+        }
+        candidates.remove(guestSessionId);
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
@@ -159,7 +159,12 @@ public final class P2PConnectionManager {
             joinInfos.put(hostSessionId, info);
                 LOGGER.info("[FireflyMC] P2P Host 开始探测: room={}, session={}, udp={}:{}",
                     hostRoomId, hostSessionId, hostUdpHost, hostUdpPort);
-            channel.probeAndPunch(info, candidates.get(hostSessionId), "host");
+            channel.probeAndPunch(info, candidates.get(hostSessionId), "host").whenComplete((success, error) -> {
+                if (error != null || !Boolean.TRUE.equals(success)) {
+                    LOGGER.warn("[FireflyMC] P2P Host 探测失败，清理 session={}", info.guestSessionId());
+                    stop(info.guestSessionId());
+                }
+            });
         } catch (SocketException e) {
             LOGGER.warn("[FireflyMC] P2P Host UDP channel create failed: {}", e.getMessage());
         }

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
@@ -38,8 +38,8 @@ public final class P2PConnectionManager {
     public CompletableFuture<P2PResult> tryGuestConnect(P2PJoinInfo info) {
         CompletableFuture<P2PResult> result = new CompletableFuture<>();
         if (!info.isUsable()) {
-            LOGGER.warn("[FireflyMC] P2P join info incomplete, fallback to relay: room={}, session={}, udp={}:{}",
-                    info.roomId(), info.guestSessionId(), info.udpHost(), info.udpPort());
+            LOGGER.warn("[FireflyMC] P2P join info incomplete, fallback to relay: room={}, session={}, udpPort={}",
+                    info.roomId(), info.guestSessionId(), info.udpPort());
             result.complete(P2PResult.failed("p2p_join_info_incomplete"));
             return result;
         }
@@ -47,8 +47,8 @@ public final class P2PConnectionManager {
             ReliableUdpChannel channel = new ReliableUdpChannel();
             channels.put(info.guestSessionId(), channel);
             joinInfos.put(info.guestSessionId(), info);
-                LOGGER.info("[FireflyMC] P2P Guest 开始连接: room={}, session={}, udp={}:{} (raw={})",
-                    info.roomId(), info.guestSessionId(), info.effectiveUdpHost(), info.udpPort(), info.udpHost());
+                LOGGER.info("[FireflyMC] P2P Guest 开始连接: room={}, session={}, udpPort={}",
+                    info.roomId(), info.guestSessionId(), info.udpPort());
             RelayLobbyWebSocketClient.getInstance().sendControl(
                     RelayLobbyMessage.p2pOffer(info.roomId(), info.guestSessionId(), info.p2pSessionId(), info.p2pToken())
             );
@@ -80,8 +80,8 @@ public final class P2PConnectionManager {
             return;
         }
         if ("p2p_udp_observed".equals(message.type()) && message.candidate() != null) {
-            LOGGER.info("[FireflyMC] P2P 服务端观测本端 UDP: role={}, candidate={}:{}",
-                    message.role(), message.candidate().address(), message.candidate().port());
+            LOGGER.info("[FireflyMC] P2P 服务端观测本端 UDP: role={}, udpPort={}",
+                    message.role(), message.candidate().port());
         } else if ("p2p_candidate".equals(message.type()) && message.candidate() != null) {
             if (message.guestSessionId() == null) {
                 return;
@@ -98,8 +98,8 @@ public final class P2PConnectionManager {
             }
             String candidateKey = raw.address() + ":" + raw.port();
             if (!candidateKey.equals(loggedCandidates.put(message.guestSessionId(), candidateKey))) {
-                LOGGER.info("[FireflyMC] P2P 收到对端候选: session={}, candidate={}:{}",
-                        message.guestSessionId(), raw.address(), raw.port());
+                LOGGER.info("[FireflyMC] P2P 收到对端候选: session={}, udpPort={}",
+                        message.guestSessionId(), raw.port());
             }
         } else if ("guest_joined".equals(message.type()) && message.p2pSupported()) {
             if (message.guestSessionId() == null) {
@@ -157,8 +157,8 @@ public final class P2PConnectionManager {
             channels.put(hostSessionId, channel);
             P2PJoinInfo info = new P2PJoinInfo(hostRoomId, hostSessionId, hostRoomId, hostToken, hostUdpHost, hostUdpPort, 10);
             joinInfos.put(hostSessionId, info);
-                LOGGER.info("[FireflyMC] P2P Host 开始探测: room={}, session={}, udp={}:{}",
-                    hostRoomId, hostSessionId, hostUdpHost, hostUdpPort);
+                LOGGER.info("[FireflyMC] P2P Host 开始探测: room={}, session={}, udpPort={}",
+                    hostRoomId, hostSessionId, hostUdpPort);
             channel.probeAndPunch(info, candidates.get(hostSessionId), "host").whenComplete((success, error) -> {
                 if (error != null || !Boolean.TRUE.equals(success)) {
                     LOGGER.warn("[FireflyMC] P2P Host 探测失败，清理 session={}", info.guestSessionId());

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
@@ -20,7 +20,7 @@ public final class P2PConnectionManager {
     private final Map<String, P2PCandidate> candidates = new ConcurrentHashMap<>();
     private final Map<String, P2PJoinInfo> joinInfos = new ConcurrentHashMap<>();
     private final Map<String, String> loggedCandidates = new ConcurrentHashMap<>();
-    private volatile P2PHostBridge hostBridge;
+    private final Map<String, P2PHostBridge> hostBridges = new ConcurrentHashMap<>();
     private volatile int hostLanPort = -1;
     private volatile String hostRoomId;
     private volatile String hostSessionId;
@@ -126,10 +126,8 @@ public final class P2PConnectionManager {
     }
 
     public void stopHost() {
-        if (hostBridge != null) {
-            hostBridge.stop();
-            hostBridge = null;
-        }
+        hostBridges.values().forEach(P2PHostBridge::stop);
+        hostBridges.clear();
         if (hostSessionId != null) {
             stop(hostSessionId);
         }
@@ -169,8 +167,9 @@ public final class P2PConnectionManager {
 
     private void startHostBridge() {
         ReliableUdpChannel channel = channels.get(hostSessionId);
-        if (channel != null && hostLanPort > 0 && hostBridge == null) {
-            hostBridge = new P2PHostBridge(hostLanPort, channel);
+        if (channel != null && hostLanPort > 0 && !hostBridges.containsKey(hostSessionId)) {
+            P2PHostBridge hostBridge = new P2PHostBridge(hostLanPort, channel);
+            hostBridges.put(hostSessionId, hostBridge);
             hostBridge.startDefaultStream();
             LOGGER.info("[FireflyMC] P2P Host bridge started for LAN port {}", hostLanPort);
         }
@@ -183,5 +182,9 @@ public final class P2PConnectionManager {
         }
         candidates.remove(guestSessionId);
         joinInfos.remove(guestSessionId);
+        P2PHostBridge bridge = hostBridges.remove(guestSessionId);
+        if (bridge != null) {
+            bridge.stop();
+        }
     }
 }

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
@@ -18,6 +18,14 @@ public final class P2PConnectionManager {
 
     private final Map<String, ReliableUdpChannel> channels = new ConcurrentHashMap<>();
     private final Map<String, P2PCandidate> candidates = new ConcurrentHashMap<>();
+    private final Map<String, P2PJoinInfo> joinInfos = new ConcurrentHashMap<>();
+    private volatile P2PHostBridge hostBridge;
+    private volatile int hostLanPort = -1;
+    private volatile String hostRoomId;
+    private volatile String hostSessionId;
+    private volatile String hostToken;
+    private volatile String hostUdpHost;
+    private volatile int hostUdpPort = -1;
 
     private P2PConnectionManager() {
     }
@@ -37,6 +45,9 @@ public final class P2PConnectionManager {
         try {
             ReliableUdpChannel channel = new ReliableUdpChannel();
             channels.put(info.guestSessionId(), channel);
+            joinInfos.put(info.guestSessionId(), info);
+            LOGGER.info("[FireflyMC] P2P Guest 开始连接: room={}, session={}, udp={}:{}",
+                    info.roomId(), info.guestSessionId(), info.udpHost(), info.udpPort());
             RelayLobbyWebSocketClient.getInstance().sendControl(
                     RelayLobbyMessage.p2pOffer(info.roomId(), info.guestSessionId(), info.p2pSessionId(), info.p2pToken())
             );
@@ -47,13 +58,14 @@ public final class P2PConnectionManager {
                             RelayLobbyMessage.relayFallback(info.roomId(), info.guestSessionId(), info.p2pSessionId(), info.p2pToken(), "p2p_timeout")
                     );
                     result.complete(P2PResult.failed("p2p_timeout"));
+                    LOGGER.warn("[FireflyMC] P2P Guest 连接失败，回退中继: room={}, session={}", info.roomId(), info.guestSessionId());
                     return;
                 }
                 RelayLobbyWebSocketClient.getInstance().sendControl(
                         RelayLobbyMessage.p2pReady(info.roomId(), info.guestSessionId(), info.p2pSessionId(), info.p2pToken())
                 );
-                // The reliable stream bridge is reserved for the next increment; fallback remains safe.
-                result.complete(P2PResult.failed("p2p_stream_bridge_not_ready"));
+                result.complete(P2PResult.success(-1, channel));
+                LOGGER.info("[FireflyMC] P2P Guest 连接成功: room={}, session={}", info.roomId(), info.guestSessionId());
             });
         } catch (SocketException e) {
             LOGGER.warn("[FireflyMC] P2P UDP channel create failed: {}", e.getMessage());
@@ -67,6 +79,9 @@ public final class P2PConnectionManager {
             return;
         }
         if ("p2p_udp_observed".equals(message.type()) && message.candidate() != null) {
+            LOGGER.info("[FireflyMC] P2P 服务端观测本端 UDP: role={}, candidate={}:{}",
+                    message.role(), message.candidate().address(), message.candidate().port());
+        } else if ("p2p_candidate".equals(message.type()) && message.candidate() != null) {
             RelayControlMessage.P2PCandidate raw = message.candidate();
             P2PCandidate candidate = new P2PCandidate(raw.address(), raw.port());
             candidates.put(message.guestSessionId(), candidate);
@@ -74,6 +89,69 @@ public final class P2PConnectionManager {
             if (channel != null) {
                 channel.setPeerCandidate(candidate);
             }
+            LOGGER.info("[FireflyMC] P2P 收到对端候选: session={}, candidate={}:{}",
+                    message.guestSessionId(), raw.address(), raw.port());
+        } else if ("guest_joined".equals(message.type()) && message.p2pSupported()) {
+            hostSessionId = message.guestSessionId();
+            hostRoomId = message.roomId();
+            hostToken = message.p2pToken();
+            startHostProbeIfReady();
+        } else if ("host_open_ack".equals(message.type()) && message.p2pSupported()) {
+            hostRoomId = message.roomId();
+            hostToken = message.p2pToken();
+            hostUdpHost = message.p2pUdpHost();
+            hostUdpPort = message.p2pUdpPort();
+            startHostProbeIfReady();
+        } else if ("p2p_ready".equals(message.type())) {
+            startHostBridge();
+        }
+    }
+
+    public void prepareHost(String roomId, int lanPort) {
+        this.hostRoomId = roomId;
+        this.hostLanPort = lanPort;
+    }
+
+    public void stopHost() {
+        if (hostBridge != null) {
+            hostBridge.stop();
+            hostBridge = null;
+        }
+        if (hostSessionId != null) {
+            stop(hostSessionId);
+        }
+        hostLanPort = -1;
+        hostRoomId = null;
+        hostSessionId = null;
+        hostToken = null;
+        hostUdpHost = null;
+        hostUdpPort = -1;
+    }
+
+    private void startHostProbeIfReady() {
+        if (hostRoomId == null || hostSessionId == null || hostToken == null || hostLanPort <= 0
+                || hostUdpHost == null || hostUdpHost.isBlank() || hostUdpPort <= 0) {
+            return;
+        }
+        try {
+            ReliableUdpChannel channel = new ReliableUdpChannel();
+            channels.put(hostSessionId, channel);
+            P2PJoinInfo info = new P2PJoinInfo(hostRoomId, hostSessionId, hostRoomId, hostToken, hostUdpHost, hostUdpPort, 10);
+            joinInfos.put(hostSessionId, info);
+                LOGGER.info("[FireflyMC] P2P Host 开始探测: room={}, session={}, udp={}:{}",
+                    hostRoomId, hostSessionId, hostUdpHost, hostUdpPort);
+            channel.probeAndPunch(info, candidates.get(hostSessionId), "host");
+        } catch (SocketException e) {
+            LOGGER.warn("[FireflyMC] P2P Host UDP channel create failed: {}", e.getMessage());
+        }
+    }
+
+    private void startHostBridge() {
+        ReliableUdpChannel channel = channels.get(hostSessionId);
+        if (channel != null && hostLanPort > 0 && hostBridge == null) {
+            hostBridge = new P2PHostBridge(hostLanPort, channel);
+            hostBridge.startDefaultStream();
+            LOGGER.info("[FireflyMC] P2P Host bridge started for LAN port {}", hostLanPort);
         }
     }
 
@@ -83,5 +161,6 @@ public final class P2PConnectionManager {
             channel.close();
         }
         candidates.remove(guestSessionId);
+        joinInfos.remove(guestSessionId);
     }
 }

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PConnectionManager.java
@@ -19,6 +19,7 @@ public final class P2PConnectionManager {
     private final Map<String, ReliableUdpChannel> channels = new ConcurrentHashMap<>();
     private final Map<String, P2PCandidate> candidates = new ConcurrentHashMap<>();
     private final Map<String, P2PJoinInfo> joinInfos = new ConcurrentHashMap<>();
+    private final Map<String, String> loggedCandidates = new ConcurrentHashMap<>();
     private volatile P2PHostBridge hostBridge;
     private volatile int hostLanPort = -1;
     private volatile String hostRoomId;
@@ -46,8 +47,8 @@ public final class P2PConnectionManager {
             ReliableUdpChannel channel = new ReliableUdpChannel();
             channels.put(info.guestSessionId(), channel);
             joinInfos.put(info.guestSessionId(), info);
-            LOGGER.info("[FireflyMC] P2P Guest 开始连接: room={}, session={}, udp={}:{}",
-                    info.roomId(), info.guestSessionId(), info.udpHost(), info.udpPort());
+                LOGGER.info("[FireflyMC] P2P Guest 开始连接: room={}, session={}, udp={}:{} (raw={})",
+                    info.roomId(), info.guestSessionId(), info.effectiveUdpHost(), info.udpPort(), info.udpHost());
             RelayLobbyWebSocketClient.getInstance().sendControl(
                     RelayLobbyMessage.p2pOffer(info.roomId(), info.guestSessionId(), info.p2pSessionId(), info.p2pToken())
             );
@@ -75,13 +76,16 @@ public final class P2PConnectionManager {
     }
 
     public void handleControlMessage(RelayControlMessage message) {
-        if (message == null || message.guestSessionId() == null) {
+        if (message == null || message.type() == null) {
             return;
         }
         if ("p2p_udp_observed".equals(message.type()) && message.candidate() != null) {
             LOGGER.info("[FireflyMC] P2P 服务端观测本端 UDP: role={}, candidate={}:{}",
                     message.role(), message.candidate().address(), message.candidate().port());
         } else if ("p2p_candidate".equals(message.type()) && message.candidate() != null) {
+            if (message.guestSessionId() == null) {
+                return;
+            }
             RelayControlMessage.P2PCandidate raw = message.candidate();
             P2PCandidate candidate = new P2PCandidate(raw.address(), raw.port());
             candidates.put(message.guestSessionId(), candidate);
@@ -89,9 +93,18 @@ public final class P2PConnectionManager {
             if (channel != null) {
                 channel.setPeerCandidate(candidate);
             }
-            LOGGER.info("[FireflyMC] P2P 收到对端候选: session={}, candidate={}:{}",
-                    message.guestSessionId(), raw.address(), raw.port());
+            if (message.guestSessionId().equals(hostSessionId)) {
+                startHostProbeIfReady();
+            }
+            String candidateKey = raw.address() + ":" + raw.port();
+            if (!candidateKey.equals(loggedCandidates.put(message.guestSessionId(), candidateKey))) {
+                LOGGER.info("[FireflyMC] P2P 收到对端候选: session={}, candidate={}:{}",
+                        message.guestSessionId(), raw.address(), raw.port());
+            }
         } else if ("guest_joined".equals(message.type()) && message.p2pSupported()) {
+            if (message.guestSessionId() == null) {
+                return;
+            }
             hostSessionId = message.guestSessionId();
             hostRoomId = message.roomId();
             hostToken = message.p2pToken();
@@ -134,6 +147,14 @@ public final class P2PConnectionManager {
             return;
         }
         try {
+            if (channels.containsKey(hostSessionId)) {
+                ReliableUdpChannel channel = channels.get(hostSessionId);
+                P2PCandidate candidate = candidates.get(hostSessionId);
+                if (channel != null && candidate != null) {
+                    channel.setPeerCandidate(candidate);
+                }
+                return;
+            }
             ReliableUdpChannel channel = new ReliableUdpChannel();
             channels.put(hostSessionId, channel);
             P2PJoinInfo info = new P2PJoinInfo(hostRoomId, hostSessionId, hostRoomId, hostToken, hostUdpHost, hostUdpPort, 10);

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PGuestProxy.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PGuestProxy.java
@@ -1,0 +1,102 @@
+package firefly520.fireflymc.client.relay.p2p;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screens.ConnectScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.multiplayer.resolver.ServerAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/** Guest-side local TCP proxy backed by a P2P UDP channel. */
+public class P2PGuestProxy {
+    private static final Logger LOGGER = LoggerFactory.getLogger(P2PGuestProxy.class);
+    private static final int BUFFER_SIZE = 512 * 1024;
+    private static final int SOCKET_BUFFER_SIZE = 2 * 1024 * 1024;
+    private static final int STREAM_ID = 1;
+
+    private final ReliableUdpChannel channel;
+    private final ExecutorService executor = Executors.newCachedThreadPool(r -> {
+        Thread thread = new Thread(r, "FireflyMC-P2P-Guest-Proxy");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private ServerSocket serverSocket;
+    private int localPort = -1;
+
+    public P2PGuestProxy(ReliableUdpChannel channel) {
+        this.channel = channel;
+    }
+
+    public int start() throws IOException {
+        if (!running.compareAndSet(false, true)) {
+            return localPort;
+        }
+        serverSocket = new ServerSocket(0);
+        serverSocket.setReuseAddress(true);
+        localPort = serverSocket.getLocalPort();
+        executor.execute(this::acceptLoop);
+        LOGGER.info("[FireflyMC] P2P Guest 本地代理已启动: 127.0.0.1:{}", localPort);
+        return localPort;
+    }
+
+    public void connectMinecraft(Screen parent, String worldName) {
+        String addressText = "127.0.0.1:" + localPort;
+        ServerAddress address = ServerAddress.parseString(addressText);
+        ServerData serverData = new ServerData("FireflyMC P2P - " + worldName, addressText, ServerData.Type.OTHER);
+        ConnectScreen.startConnecting(parent, Minecraft.getInstance(), address, serverData, false, null);
+    }
+
+    public void stop() {
+        running.set(false);
+        try {
+            if (serverSocket != null) {
+                serverSocket.close();
+            }
+        } catch (IOException ignored) {
+        }
+        channel.unregisterStream(STREAM_ID);
+        executor.shutdownNow();
+    }
+
+    private void acceptLoop() {
+        while (running.get()) {
+            try {
+                Socket socket = serverSocket.accept();
+                socket.setTcpNoDelay(true);
+                socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
+                socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
+                channel.registerStream(STREAM_ID, socket.getOutputStream());
+                executor.execute(() -> pipeLocalToP2P(socket));
+            } catch (IOException e) {
+                if (running.get()) {
+                    LOGGER.warn("[FireflyMC] P2P Guest 接受本地连接失败: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    private void pipeLocalToP2P(Socket socket) {
+        byte[] buffer = new byte[BUFFER_SIZE];
+        try (Socket ignored = socket; InputStream input = socket.getInputStream()) {
+            int read;
+            while (running.get() && (read = input.read(buffer)) != -1) {
+                channel.sendData(STREAM_ID, buffer, read);
+            }
+        } catch (IOException e) {
+            LOGGER.debug("[FireflyMC] P2P Guest 本地流关闭: {}", e.getMessage());
+        } finally {
+            channel.sendFin(STREAM_ID);
+            channel.unregisterStream(STREAM_ID);
+        }
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PGuestProxy.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PGuestProxy.java
@@ -15,6 +15,7 @@ import java.net.Socket;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /** Guest-side local TCP proxy backed by a P2P UDP channel. */
 public class P2PGuestProxy {
@@ -30,6 +31,7 @@ public class P2PGuestProxy {
         return thread;
     });
     private final AtomicBoolean running = new AtomicBoolean(false);
+    private final AtomicLong localToP2pBytes = new AtomicLong(0);
     private ServerSocket serverSocket;
     private int localPort = -1;
 
@@ -76,6 +78,7 @@ public class P2PGuestProxy {
                 socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
                 socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
                 channel.registerStream(STREAM_ID, socket.getOutputStream());
+                LOGGER.info("[FireflyMC] P2P Guest 本地 Minecraft 已连接代理: streamId={}", STREAM_ID);
                 executor.execute(() -> pipeLocalToP2P(socket));
             } catch (IOException e) {
                 if (running.get()) {
@@ -91,6 +94,10 @@ public class P2PGuestProxy {
             int read;
             while (running.get() && (read = input.read(buffer)) != -1) {
                 channel.sendData(STREAM_ID, buffer, read);
+                localToP2pBytes.addAndGet(read);
+                if (localToP2pBytes.get() <= 8192 || read > 1000) {
+                    LOGGER.info("[FireflyMC] P2P Guest 本地→UDP: {} bytes, total={} KB", read, localToP2pBytes.get() / 1024);
+                }
             }
         } catch (IOException e) {
             LOGGER.debug("[FireflyMC] P2P Guest 本地流关闭: {}", e.getMessage());

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PGuestProxy.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PGuestProxy.java
@@ -67,6 +67,7 @@ public class P2PGuestProxy {
         } catch (IOException ignored) {
         }
         channel.unregisterStream(STREAM_ID);
+        channel.close();
         executor.shutdownNow();
     }
 
@@ -102,7 +103,9 @@ public class P2PGuestProxy {
         } catch (IOException e) {
             LOGGER.debug("[FireflyMC] P2P Guest 本地流关闭: {}", e.getMessage());
         } finally {
-            channel.sendFin(STREAM_ID);
+            if (channel.isRunning()) {
+                channel.sendFin(STREAM_ID);
+            }
             channel.unregisterStream(STREAM_ID);
         }
     }

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PHostBridge.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PHostBridge.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
 
 /** Host-side bridge from P2P UDP streams to local integrated-server LAN TCP. */
 public class P2PHostBridge {
@@ -26,6 +27,7 @@ public class P2PHostBridge {
         return thread;
     });
     private final Map<Integer, Socket> sockets = new ConcurrentHashMap<>();
+    private final AtomicLong lanToP2pBytes = new AtomicLong(0);
 
     public P2PHostBridge(int lanPort, ReliableUdpChannel channel) {
         this.lanPort = lanPort;
@@ -33,6 +35,7 @@ public class P2PHostBridge {
     }
 
     public void startDefaultStream() {
+        LOGGER.info("[FireflyMC] P2P Host 正在打开默认 stream 到本地 LAN: port={}", lanPort);
         openStream(STREAM_ID);
     }
 
@@ -60,6 +63,7 @@ public class P2PHostBridge {
                 socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
                 sockets.put(streamId, socket);
                 channel.registerStream(streamId, socket.getOutputStream());
+                LOGGER.info("[FireflyMC] P2P Host 已连接本地 LAN: streamId={}, port={}", streamId, lanPort);
                 pipeLanToP2P(streamId, socket);
             } catch (IOException e) {
                 LOGGER.warn("[FireflyMC] P2P Host 连接本地 LAN 失败: {}", e.getMessage());
@@ -73,6 +77,10 @@ public class P2PHostBridge {
             int read;
             while ((read = input.read(buffer)) != -1) {
                 channel.sendData(streamId, buffer, read);
+                lanToP2pBytes.addAndGet(read);
+                if (lanToP2pBytes.get() <= 8192 || read > 1000) {
+                    LOGGER.info("[FireflyMC] P2P Host LAN→UDP: {} bytes, total={} KB", read, lanToP2pBytes.get() / 1024);
+                }
             }
         } catch (IOException e) {
             LOGGER.debug("[FireflyMC] P2P Host LAN 流关闭: {}", e.getMessage());

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PHostBridge.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PHostBridge.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 
 /** Host-side bridge from P2P UDP streams to local integrated-server LAN TCP. */
@@ -28,6 +29,7 @@ public class P2PHostBridge {
     });
     private final Map<Integer, Socket> sockets = new ConcurrentHashMap<>();
     private final AtomicLong lanToP2pBytes = new AtomicLong(0);
+    private final AtomicBoolean running = new AtomicBoolean(true);
 
     public P2PHostBridge(int lanPort, ReliableUdpChannel channel) {
         this.lanPort = lanPort;
@@ -40,6 +42,7 @@ public class P2PHostBridge {
     }
 
     public void stop() {
+        running.set(false);
         sockets.values().forEach(socket -> {
             try {
                 socket.close();
@@ -75,7 +78,8 @@ public class P2PHostBridge {
         byte[] buffer = new byte[BUFFER_SIZE];
         try (Socket ignored = socket; InputStream input = socket.getInputStream()) {
             int read;
-            while ((read = input.read(buffer)) != -1) {
+            while (running.get() && (read = input.read(buffer)) != -1) {
+                if (!running.get()) break;
                 channel.sendData(streamId, buffer, read);
                 lanToP2pBytes.addAndGet(read);
                 if (lanToP2pBytes.get() <= 8192 || read > 1000) {
@@ -83,10 +87,14 @@ public class P2PHostBridge {
                 }
             }
         } catch (IOException e) {
-            LOGGER.debug("[FireflyMC] P2P Host LAN 流关闭: {}", e.getMessage());
+            if (running.get()) {
+                LOGGER.debug("[FireflyMC] P2P Host LAN 流关闭: {}", e.getMessage());
+            }
         } finally {
             sockets.remove(streamId);
-            channel.sendFin(streamId);
+            if (channel.isRunning()) {
+                channel.sendFin(streamId);
+            }
             channel.unregisterStream(streamId);
         }
     }

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PHostBridge.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PHostBridge.java
@@ -1,0 +1,85 @@
+package firefly520.fireflymc.client.relay.p2p;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.Socket;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/** Host-side bridge from P2P UDP streams to local integrated-server LAN TCP. */
+public class P2PHostBridge {
+    private static final Logger LOGGER = LoggerFactory.getLogger(P2PHostBridge.class);
+    private static final int BUFFER_SIZE = 512 * 1024;
+    private static final int SOCKET_BUFFER_SIZE = 2 * 1024 * 1024;
+    private static final int STREAM_ID = 1;
+
+    private final int lanPort;
+    private final ReliableUdpChannel channel;
+    private final ExecutorService executor = Executors.newCachedThreadPool(r -> {
+        Thread thread = new Thread(r, "FireflyMC-P2P-Host-Bridge");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final Map<Integer, Socket> sockets = new ConcurrentHashMap<>();
+
+    public P2PHostBridge(int lanPort, ReliableUdpChannel channel) {
+        this.lanPort = lanPort;
+        this.channel = channel;
+    }
+
+    public void startDefaultStream() {
+        openStream(STREAM_ID);
+    }
+
+    public void stop() {
+        sockets.values().forEach(socket -> {
+            try {
+                socket.close();
+            } catch (IOException ignored) {
+            }
+        });
+        sockets.clear();
+        channel.unregisterStream(STREAM_ID);
+        executor.shutdownNow();
+    }
+
+    private void openStream(int streamId) {
+        if (sockets.containsKey(streamId)) {
+            return;
+        }
+        executor.execute(() -> {
+            try {
+                Socket socket = new Socket("127.0.0.1", lanPort);
+                socket.setTcpNoDelay(true);
+                socket.setReceiveBufferSize(SOCKET_BUFFER_SIZE);
+                socket.setSendBufferSize(SOCKET_BUFFER_SIZE);
+                sockets.put(streamId, socket);
+                channel.registerStream(streamId, socket.getOutputStream());
+                pipeLanToP2P(streamId, socket);
+            } catch (IOException e) {
+                LOGGER.warn("[FireflyMC] P2P Host 连接本地 LAN 失败: {}", e.getMessage());
+            }
+        });
+    }
+
+    private void pipeLanToP2P(int streamId, Socket socket) {
+        byte[] buffer = new byte[BUFFER_SIZE];
+        try (Socket ignored = socket; InputStream input = socket.getInputStream()) {
+            int read;
+            while ((read = input.read(buffer)) != -1) {
+                channel.sendData(streamId, buffer, read);
+            }
+        } catch (IOException e) {
+            LOGGER.debug("[FireflyMC] P2P Host LAN 流关闭: {}", e.getMessage());
+        } finally {
+            sockets.remove(streamId);
+            channel.sendFin(streamId);
+            channel.unregisterStream(streamId);
+        }
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PJoinInfo.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PJoinInfo.java
@@ -1,0 +1,20 @@
+package firefly520.fireflymc.client.relay.p2p;
+
+public record P2PJoinInfo(
+        String roomId,
+        String guestSessionId,
+        String p2pSessionId,
+        String p2pToken,
+        String udpHost,
+        int udpPort,
+        int timeoutSeconds
+) {
+    public boolean isUsable() {
+        return roomId != null && !roomId.isBlank()
+                && guestSessionId != null && !guestSessionId.isBlank()
+                && p2pSessionId != null && !p2pSessionId.isBlank()
+                && p2pToken != null && !p2pToken.isBlank()
+                && udpHost != null && !udpHost.isBlank()
+                && udpPort > 0 && udpPort <= 65535;
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PJoinInfo.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PJoinInfo.java
@@ -9,6 +9,8 @@ public record P2PJoinInfo(
         int udpPort,
         int timeoutSeconds
 ) {
+    private static final String RELAY_HOST_FALLBACK = resolveRelayHostFallback();
+
     public boolean isUsable() {
         return roomId != null && !roomId.isBlank()
                 && guestSessionId != null && !guestSessionId.isBlank()
@@ -16,5 +18,21 @@ public record P2PJoinInfo(
                 && p2pToken != null && !p2pToken.isBlank()
                 && udpHost != null && !udpHost.isBlank()
                 && udpPort > 0 && udpPort <= 65535;
+    }
+
+    public String effectiveUdpHost() {
+        if (udpHost == null || udpHost.isBlank() || "0.0.0.0".equals(udpHost) || "127.0.0.1".equals(udpHost) || "localhost".equalsIgnoreCase(udpHost)) {
+            return RELAY_HOST_FALLBACK;
+        }
+        return udpHost;
+    }
+
+    private static String resolveRelayHostFallback() {
+        try {
+            String relayUrl = firefly520.fireflymc.Config.CLIENT.SINGLEPLAYER_RELAY_URL.get();
+            return java.net.URI.create(relayUrl).getHost();
+        } catch (Exception ignored) {
+            return "";
+        }
     }
 }

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PResult.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PResult.java
@@ -1,0 +1,11 @@
+package firefly520.fireflymc.client.relay.p2p;
+
+public record P2PResult(boolean success, int localPort, String reason) {
+    public static P2PResult success(int localPort) {
+        return new P2PResult(true, localPort, "ok");
+    }
+
+    public static P2PResult failed(String reason) {
+        return new P2PResult(false, -1, reason == null ? "failed" : reason);
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PResult.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/P2PResult.java
@@ -1,11 +1,11 @@
 package firefly520.fireflymc.client.relay.p2p;
 
-public record P2PResult(boolean success, int localPort, String reason) {
-    public static P2PResult success(int localPort) {
-        return new P2PResult(true, localPort, "ok");
+public record P2PResult(boolean success, int localPort, String reason, ReliableUdpChannel channel) {
+    public static P2PResult success(int localPort, ReliableUdpChannel channel) {
+        return new P2PResult(true, localPort, "ok", channel);
     }
 
     public static P2PResult failed(String reason) {
-        return new P2PResult(false, -1, reason == null ? "failed" : reason);
+        return new P2PResult(false, -1, reason == null ? "failed" : reason, null);
     }
 }

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
@@ -57,11 +57,13 @@ public class ReliableUdpChannel {
     private final AtomicLong receivedBytes = new AtomicLong(0);
     private final AtomicLong nextSentLogAt = new AtomicLong(64 * 1024);
     private final AtomicLong nextReceivedLogAt = new AtomicLong(64 * 1024);
+    private final SendWindow sendWindow;
 
     public ReliableUdpChannel() throws SocketException {
         this.socket = createSocket();
         this.receiverThread = new Thread(this::receiveLoop, "FireflyMC-P2P-UDP-Receiver");
         this.receiverThread.setDaemon(true);
+        this.sendWindow = new SendWindow(executor, this::send);
     }
 
     public int localPort() {
@@ -98,6 +100,7 @@ public class ReliableUdpChannel {
             }
             if (observedByServer && punchedPeer && !result.isDone()) {
                 LOGGER.info("[FireflyMC] P2P {} 打洞完成: peer={}", role, peerAddress);
+                sendWindow.start();
                 result.complete(true);
             }
         }, 0, 300, TimeUnit.MILLISECONDS);
@@ -154,8 +157,7 @@ public class ReliableUdpChannel {
             int seq = nextSeq.getAndIncrement();
             byte[] packet = UdpPacketCodec.data(streamId, seq, lastAck.get(), (byte) 0, payload, payload.length);
             send(peer, packet);
-            // Temporary redundancy until full retransmit queue is implemented.
-            send(peer, packet);
+            sendWindow.record(seq, packet, peer);
             long totalSent = sentBytes.addAndGet(payload.length);
             long threshold = nextSentLogAt.get();
             if (totalSent <= 8192 || totalSent >= threshold) {
@@ -176,6 +178,7 @@ public class ReliableUdpChannel {
 
     public void close() {
         running.set(false);
+        sendWindow.close();
         socket.close();
         executor.shutdownNow();
     }
@@ -221,17 +224,19 @@ public class ReliableUdpChannel {
         }
         peerAddress = new InetSocketAddress(source.getAddress(), source.getPort());
         if ((decoded.flags() & UdpPacketCodec.FLAG_ACK) != 0) {
+            sendWindow.acknowledge(decoded.ack());
             return;
         }
         lastAck.set(Math.max(lastAck.get(), decoded.seq()));
+        // Send ACK back to peer
+        InetSocketAddress peer = peerAddress;
+        if (peer != null) {
+            ReorderBuffer reorder = reorderBuffers.computeIfAbsent(decoded.streamId(), ignored -> new ReorderBuffer());
+            send(peer, UdpPacketCodec.ack(decoded.streamId(), reorder.ackSeq()));
+        }
         OutputStream output = outputs.get(decoded.streamId());
         if (output != null && decoded.payload().length > 0) {
             writeDecodedPayload(decoded, output);
-            InetSocketAddress peer = peerAddress;
-            if (peer != null) {
-                ReorderBuffer reorder = reorderBuffers.computeIfAbsent(decoded.streamId(), ignored -> new ReorderBuffer());
-                send(peer, UdpPacketCodec.ack(decoded.streamId(), reorder.ackSeq()));
-            }
         } else if (decoded.payload().length > 0) {
             List<UdpPacketCodec.DecodedData> pending = pendingBeforeRegister.computeIfAbsent(
                     decoded.streamId(), ignored -> Collections.synchronizedList(new ArrayList<>())

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
@@ -55,6 +55,8 @@ public class ReliableUdpChannel {
     private final AtomicInteger lastAck = new AtomicInteger(0);
     private final AtomicLong sentBytes = new AtomicLong(0);
     private final AtomicLong receivedBytes = new AtomicLong(0);
+    private final AtomicLong nextSentLogAt = new AtomicLong(64 * 1024);
+    private final AtomicLong nextReceivedLogAt = new AtomicLong(64 * 1024);
 
     public ReliableUdpChannel() throws SocketException {
         this.socket = createSocket();
@@ -154,10 +156,12 @@ public class ReliableUdpChannel {
             send(peer, packet);
             // Temporary redundancy until full retransmit queue is implemented.
             send(peer, packet);
-            sentBytes.addAndGet(payload.length);
-            if (sentBytes.get() <= 8192 || payload.length > 1000) {
-                LOGGER.info("[FireflyMC] P2P UDP 发送数据: stream={}, seq={}, bytes={}, total={} KB, peer={}",
-                        streamId, seq, payload.length, sentBytes.get() / 1024, peer);
+            long totalSent = sentBytes.addAndGet(payload.length);
+            long threshold = nextSentLogAt.get();
+            if (totalSent <= 8192 || totalSent >= threshold) {
+                nextSentLogAt.compareAndSet(threshold, threshold + 64 * 1024);
+                LOGGER.info("[FireflyMC] P2P UDP 发送进度: stream={}, seq={}, chunk={} bytes, total={} KB, peer={}",
+                        streamId, seq, payload.length, totalSent / 1024, peer);
             }
             offset += chunk;
         }
@@ -246,8 +250,13 @@ public class ReliableUdpChannel {
             reorder.accept(decoded.seq(), decoded.payload(), output);
             receivedBytes.addAndGet(decoded.payload().length);
             if (receivedBytes.get() <= 8192 || decoded.payload().length > 1000) {
-                LOGGER.info("[FireflyMC] P2P UDP 接收数据: stream={}, seq={}, bytes={}, total={} KB",
-                        decoded.streamId(), decoded.seq(), decoded.payload().length, receivedBytes.get() / 1024);
+                long totalReceived = receivedBytes.get();
+                long threshold = nextReceivedLogAt.get();
+                if (totalReceived <= 8192 || totalReceived >= threshold) {
+                    nextReceivedLogAt.compareAndSet(threshold, threshold + 64 * 1024);
+                    LOGGER.info("[FireflyMC] P2P UDP 接收进度: stream={}, seq={}, chunk={} bytes, total={} KB",
+                            decoded.streamId(), decoded.seq(), decoded.payload().length, totalReceived / 1024);
+                }
             }
         } catch (IOException e) {
             LOGGER.debug("[FireflyMC] P2P stream write failed: {}", e.getMessage());

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
@@ -5,16 +5,20 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
-import java.time.Duration;
+import java.util.Arrays;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -33,13 +37,20 @@ public class ReliableUdpChannel {
         thread.setDaemon(true);
         return thread;
     });
+    private final Thread receiverThread;
     private final AtomicBoolean running = new AtomicBoolean(false);
     private volatile InetSocketAddress peerAddress;
     private volatile boolean observedByServer;
     private volatile boolean punchedPeer;
+    private final Map<Integer, OutputStream> outputs = new ConcurrentHashMap<>();
+    private final Map<Integer, ReorderBuffer> reorderBuffers = new ConcurrentHashMap<>();
+    private final AtomicInteger nextSeq = new AtomicInteger(1);
+    private final AtomicInteger lastAck = new AtomicInteger(0);
 
     public ReliableUdpChannel() throws SocketException {
         this.socket = createSocket();
+        this.receiverThread = new Thread(this::receiveLoop, "FireflyMC-P2P-UDP-Receiver");
+        this.receiverThread.setDaemon(true);
     }
 
     public int localPort() {
@@ -55,14 +66,19 @@ public class ReliableUdpChannel {
         running.set(true);
         if (peerCandidate != null && peerCandidate.isValid()) {
             peerAddress = peerCandidate.toSocketAddress();
+            LOGGER.info("[FireflyMC] P2P 初始 peer candidate: {}", peerAddress);
         }
-        executor.execute(this::receiveLoop);
+        if (!receiverThread.isAlive()) {
+            receiverThread.start();
+        }
         InetSocketAddress serverAddress = new InetSocketAddress(info.udpHost(), info.udpPort());
         int timeout = info.timeoutSeconds() > 0
                 ? info.timeoutSeconds()
                 : Config.CLIENT.SINGLEPLAYER_RELAY_P2P_CONNECT_TIMEOUT_SECONDS.get();
         byte[] probe = UdpPacketCodec.probe(info.roomId(), info.guestSessionId(), role, info.p2pToken());
         byte[] punch = UdpPacketCodec.punch(info.roomId(), info.guestSessionId(), role, info.p2pToken());
+        LOGGER.info("[FireflyMC] P2P {} 开始探测: server={}, localUdp={}, timeout={}s",
+            role, serverAddress, localPort(), timeout);
         ScheduledFuture<?> probeTask = executor.scheduleAtFixedRate(() -> {
             send(serverAddress, probe);
             InetSocketAddress peer = peerAddress;
@@ -70,11 +86,14 @@ public class ReliableUdpChannel {
                 send(peer, punch);
             }
             if (observedByServer && punchedPeer && !result.isDone()) {
+                LOGGER.info("[FireflyMC] P2P {} 打洞完成: peer={}", role, peerAddress);
                 result.complete(true);
             }
         }, 0, 300, TimeUnit.MILLISECONDS);
         ScheduledFuture<?> timeoutTask = executor.schedule(() -> {
             if (!result.isDone()) {
+                LOGGER.warn("[FireflyMC] P2P {} 探测超时: observedByServer={}, punchedPeer={}, peer={}",
+                        role, observedByServer, punchedPeer, peerAddress);
                 result.complete(false);
             }
         }, timeout, TimeUnit.SECONDS);
@@ -91,6 +110,39 @@ public class ReliableUdpChannel {
     public void setPeerCandidate(P2PCandidate candidate) {
         if (candidate != null && candidate.isValid()) {
             this.peerAddress = candidate.toSocketAddress();
+            LOGGER.info("[FireflyMC] P2P 更新 peer candidate: {}", this.peerAddress);
+        }
+    }
+
+    public void registerStream(int streamId, OutputStream output) {
+        outputs.put(streamId, output);
+        reorderBuffers.computeIfAbsent(streamId, ignored -> new ReorderBuffer());
+    }
+
+    public void unregisterStream(int streamId) {
+        outputs.remove(streamId);
+        reorderBuffers.remove(streamId);
+    }
+
+    public void sendData(int streamId, byte[] bytes, int length) {
+        InetSocketAddress peer = peerAddress;
+        if (peer == null || length <= 0) {
+            return;
+        }
+        int offset = 0;
+        while (offset < length) {
+            int chunk = Math.min(UdpPacketCodec.MAX_PAYLOAD_SIZE, length - offset);
+            byte[] payload = Arrays.copyOfRange(bytes, offset, offset + chunk);
+            int seq = nextSeq.getAndIncrement();
+            send(peer, UdpPacketCodec.data(streamId, seq, lastAck.get(), (byte) 0, payload, payload.length));
+            offset += chunk;
+        }
+    }
+
+    public void sendFin(int streamId) {
+        InetSocketAddress peer = peerAddress;
+        if (peer != null) {
+            send(peer, UdpPacketCodec.fin(streamId, nextSeq.getAndIncrement(), lastAck.get()));
         }
     }
 
@@ -106,12 +158,19 @@ public class ReliableUdpChannel {
             try {
                 DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
                 socket.receive(packet);
+                byte[] packetBytes = Arrays.copyOfRange(packet.getData(), packet.getOffset(), packet.getOffset() + packet.getLength());
+                if (UdpPacketCodec.isBinaryData(packetBytes)) {
+                    handleDataPacket(packetBytes, packet);
+                    continue;
+                }
                 String text = new String(packet.getData(), packet.getOffset(), packet.getLength());
                 if (text.contains("probe_ack")) {
                     observedByServer = true;
+                    LOGGER.info("[FireflyMC] P2P 已被服务端观测到: {}", text);
                 } else if (text.contains("punch")) {
                     punchedPeer = true;
                     peerAddress = new InetSocketAddress(packet.getAddress(), packet.getPort());
+                    LOGGER.info("[FireflyMC] P2P 收到对端 punch: {}", peerAddress);
                 }
             } catch (IOException e) {
                 if (running.get()) {
@@ -121,12 +180,37 @@ public class ReliableUdpChannel {
         }
     }
 
+    private void handleDataPacket(byte[] bytes, DatagramPacket source) {
+        UdpPacketCodec.DecodedData decoded = UdpPacketCodec.decodeData(bytes);
+        if (decoded == null) {
+            return;
+        }
+        peerAddress = new InetSocketAddress(source.getAddress(), source.getPort());
+        if ((decoded.flags() & UdpPacketCodec.FLAG_ACK) != 0) {
+            return;
+        }
+        lastAck.set(Math.max(lastAck.get(), decoded.seq()));
+        OutputStream output = outputs.get(decoded.streamId());
+        if (output != null && decoded.payload().length > 0) {
+            try {
+                ReorderBuffer reorder = reorderBuffers.computeIfAbsent(decoded.streamId(), ignored -> new ReorderBuffer());
+                reorder.accept(decoded.seq(), decoded.payload(), output);
+                InetSocketAddress peer = peerAddress;
+                if (peer != null) {
+                    send(peer, UdpPacketCodec.ack(decoded.streamId(), reorder.ackSeq()));
+                }
+            } catch (IOException e) {
+                LOGGER.debug("[FireflyMC] P2P stream write failed: {}", e.getMessage());
+            }
+        }
+    }
+
     private void send(InetSocketAddress target, byte[] bytes) {
         try {
             DatagramPacket packet = new DatagramPacket(bytes, bytes.length, target);
             socket.send(packet);
         } catch (IOException e) {
-            LOGGER.debug("[FireflyMC] P2P UDP send failed: {}", e.getMessage());
+            LOGGER.warn("[FireflyMC] P2P UDP send failed: target={}, error={}", target, e.getMessage());
         }
     }
 

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
@@ -81,7 +81,7 @@ public class ReliableUdpChannel {
         running.set(true);
         if (peerCandidate != null && peerCandidate.isValid()) {
             peerAddress = peerCandidate.toSocketAddress();
-            LOGGER.info("[FireflyMC] P2P 初始 peer candidate: {}", peerAddress);
+            LOGGER.info("[FireflyMC] P2P 初始 peer candidate: udpPort={}", peerAddress.getPort());
         }
         if (!receiverThread.isAlive()) {
             receiverThread.start();
@@ -92,8 +92,8 @@ public class ReliableUdpChannel {
                 : Config.CLIENT.SINGLEPLAYER_RELAY_P2P_CONNECT_TIMEOUT_SECONDS.get();
         byte[] probe = UdpPacketCodec.probe(info.roomId(), info.guestSessionId(), role, info.p2pToken());
         byte[] punch = UdpPacketCodec.punch(info.roomId(), info.guestSessionId(), role, info.p2pToken());
-        LOGGER.info("[FireflyMC] P2P {} 开始探测: server={}, localUdp={}, timeout={}s, rawUdpHost={}",
-            role, serverAddress, localPort(), timeout, info.udpHost());
+        LOGGER.info("[FireflyMC] P2P {} 开始探测: serverUdpPort={}, localUdp={}, timeout={}s",
+            role, serverAddress.getPort(), localPort(), timeout);
         ScheduledFuture<?> probeTask = executor.scheduleAtFixedRate(() -> {
             send(serverAddress, probe);
             InetSocketAddress peer = peerAddress;
@@ -101,7 +101,7 @@ public class ReliableUdpChannel {
                 send(peer, punch);
             }
             if (observedByServer && punchedPeer && !result.isDone()) {
-                LOGGER.info("[FireflyMC] P2P {} 打洞完成: peer={}", role, peerAddress);
+                LOGGER.info("[FireflyMC] P2P {} 打洞完成: peerUdpPort={}", role, peerAddress != null ? peerAddress.getPort() : -1);
                 sendWindow.start();
                 startIdleCheck();
                 result.complete(true);
@@ -109,8 +109,8 @@ public class ReliableUdpChannel {
         }, 0, 300, TimeUnit.MILLISECONDS);
         ScheduledFuture<?> timeoutTask = executor.schedule(() -> {
             if (!result.isDone()) {
-                LOGGER.warn("[FireflyMC] P2P {} 探测超时: observedByServer={}, punchedPeer={}, peer={}",
-                        role, observedByServer, punchedPeer, peerAddress);
+                LOGGER.warn("[FireflyMC] P2P {} 探测超时: observedByServer={}, punchedPeer={}, peerUdpPort={}",
+                        role, observedByServer, punchedPeer, peerAddress != null ? peerAddress.getPort() : -1);
                 result.complete(false);
             }
         }, timeout, TimeUnit.SECONDS);
@@ -127,7 +127,7 @@ public class ReliableUdpChannel {
     public void setPeerCandidate(P2PCandidate candidate) {
         if (candidate != null && candidate.isValid()) {
             this.peerAddress = candidate.toSocketAddress();
-            LOGGER.info("[FireflyMC] P2P 更新 peer candidate: {}", this.peerAddress);
+            LOGGER.info("[FireflyMC] P2P 更新 peer candidate: udpPort={}", this.peerAddress.getPort());
         }
     }
 
@@ -165,8 +165,8 @@ public class ReliableUdpChannel {
             long threshold = nextSentLogAt.get();
             if (totalSent <= 8192 || totalSent >= threshold) {
                 nextSentLogAt.compareAndSet(threshold, threshold + 64 * 1024);
-                LOGGER.info("[FireflyMC] P2P UDP 发送进度: stream={}, seq={}, chunk={} bytes, total={} KB, peer={}",
-                        streamId, seq, payload.length, totalSent / 1024, peer);
+                LOGGER.info("[FireflyMC] P2P UDP 发送进度: stream={}, seq={}, chunk={} bytes, total={} KB, peerUdpPort={}",
+                        streamId, seq, payload.length, totalSent / 1024, peer.getPort());
             }
             offset += chunk;
         }
@@ -229,7 +229,7 @@ public class ReliableUdpChannel {
                     peerAddress = new InetSocketAddress(packet.getAddress(), packet.getPort());
                     if (!loggedPunch) {
                         loggedPunch = true;
-                        LOGGER.info("[FireflyMC] P2P 收到对端 punch: {}", peerAddress);
+                        LOGGER.info("[FireflyMC] P2P 收到对端 punch: udpPort={}", peerAddress.getPort());
                     }
                 }
             } catch (IOException e) {
@@ -296,7 +296,7 @@ public class ReliableUdpChannel {
             DatagramPacket packet = new DatagramPacket(bytes, bytes.length, target);
             socket.send(packet);
         } catch (IOException e) {
-            LOGGER.warn("[FireflyMC] P2P UDP send failed: target={}, error={}", target, e.getMessage());
+            LOGGER.warn("[FireflyMC] P2P UDP send failed: targetPort={}, error={}", target.getPort(), e.getMessage());
         }
     }
 

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
@@ -1,0 +1,147 @@
+package firefly520.fireflymc.client.relay.p2p;
+
+import firefly520.fireflymc.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
+import java.net.SocketException;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * MVP reliable UDP channel shell.
+ *
+ * <p>The first implementation uses this class for NAT probe/punch orchestration and
+ * reserves the data codec for the reliable tunnel. If the channel cannot establish
+ * quickly, callers fall back to the existing WebSocket relay.</p>
+ */
+public class ReliableUdpChannel {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ReliableUdpChannel.class);
+
+    private final DatagramSocket socket;
+    private final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(r -> {
+        Thread thread = new Thread(r, "FireflyMC-P2P-UDP");
+        thread.setDaemon(true);
+        return thread;
+    });
+    private final AtomicBoolean running = new AtomicBoolean(false);
+    private volatile InetSocketAddress peerAddress;
+    private volatile boolean observedByServer;
+    private volatile boolean punchedPeer;
+
+    public ReliableUdpChannel() throws SocketException {
+        this.socket = createSocket();
+    }
+
+    public int localPort() {
+        return socket.getLocalPort();
+    }
+
+    public CompletableFuture<Boolean> probeAndPunch(P2PJoinInfo info, P2PCandidate peerCandidate, String role) {
+        CompletableFuture<Boolean> result = new CompletableFuture<>();
+        if (!info.isUsable()) {
+            result.complete(false);
+            return result;
+        }
+        running.set(true);
+        if (peerCandidate != null && peerCandidate.isValid()) {
+            peerAddress = peerCandidate.toSocketAddress();
+        }
+        executor.execute(this::receiveLoop);
+        InetSocketAddress serverAddress = new InetSocketAddress(info.udpHost(), info.udpPort());
+        int timeout = info.timeoutSeconds() > 0
+                ? info.timeoutSeconds()
+                : Config.CLIENT.SINGLEPLAYER_RELAY_P2P_CONNECT_TIMEOUT_SECONDS.get();
+        byte[] probe = UdpPacketCodec.probe(info.roomId(), info.guestSessionId(), role, info.p2pToken());
+        byte[] punch = UdpPacketCodec.punch(info.roomId(), info.guestSessionId(), role, info.p2pToken());
+        ScheduledFuture<?> probeTask = executor.scheduleAtFixedRate(() -> {
+            send(serverAddress, probe);
+            InetSocketAddress peer = peerAddress;
+            if (peer != null) {
+                send(peer, punch);
+            }
+            if (observedByServer && punchedPeer && !result.isDone()) {
+                result.complete(true);
+            }
+        }, 0, 300, TimeUnit.MILLISECONDS);
+        ScheduledFuture<?> timeoutTask = executor.schedule(() -> {
+            if (!result.isDone()) {
+                result.complete(false);
+            }
+        }, timeout, TimeUnit.SECONDS);
+        result.whenComplete((ignored, error) -> {
+            probeTask.cancel(false);
+            timeoutTask.cancel(false);
+            if (error != null || !Boolean.TRUE.equals(ignored)) {
+                close();
+            }
+        });
+        return result;
+    }
+
+    public void setPeerCandidate(P2PCandidate candidate) {
+        if (candidate != null && candidate.isValid()) {
+            this.peerAddress = candidate.toSocketAddress();
+        }
+    }
+
+    public void close() {
+        running.set(false);
+        socket.close();
+        executor.shutdownNow();
+    }
+
+    private void receiveLoop() {
+        byte[] buffer = new byte[1500];
+        while (running.get() && !socket.isClosed()) {
+            try {
+                DatagramPacket packet = new DatagramPacket(buffer, buffer.length);
+                socket.receive(packet);
+                String text = new String(packet.getData(), packet.getOffset(), packet.getLength());
+                if (text.contains("probe_ack")) {
+                    observedByServer = true;
+                } else if (text.contains("punch")) {
+                    punchedPeer = true;
+                    peerAddress = new InetSocketAddress(packet.getAddress(), packet.getPort());
+                }
+            } catch (IOException e) {
+                if (running.get()) {
+                    LOGGER.debug("[FireflyMC] P2P UDP receive failed: {}", e.getMessage());
+                }
+            }
+        }
+    }
+
+    private void send(InetSocketAddress target, byte[] bytes) {
+        try {
+            DatagramPacket packet = new DatagramPacket(bytes, bytes.length, target);
+            socket.send(packet);
+        } catch (IOException e) {
+            LOGGER.debug("[FireflyMC] P2P UDP send failed: {}", e.getMessage());
+        }
+    }
+
+    private static DatagramSocket createSocket() throws SocketException {
+        int min = Config.CLIENT.SINGLEPLAYER_RELAY_P2P_UDP_PORT_MIN.get();
+        int max = Config.CLIENT.SINGLEPLAYER_RELAY_P2P_UDP_PORT_MAX.get();
+        if (min > 0 && max >= min) {
+            for (int port = min; port <= max; port++) {
+                try {
+                    return new DatagramSocket(port);
+                } catch (SocketException ignored) {
+                    // try next port
+                }
+            }
+        }
+        return new DatagramSocket(0);
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
@@ -11,6 +11,9 @@ import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.net.SocketException;
 import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -20,6 +23,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * MVP reliable UDP channel shell.
@@ -46,8 +50,11 @@ public class ReliableUdpChannel {
     private volatile boolean loggedPunch;
     private final Map<Integer, OutputStream> outputs = new ConcurrentHashMap<>();
     private final Map<Integer, ReorderBuffer> reorderBuffers = new ConcurrentHashMap<>();
+    private final Map<Integer, List<UdpPacketCodec.DecodedData>> pendingBeforeRegister = new ConcurrentHashMap<>();
     private final AtomicInteger nextSeq = new AtomicInteger(1);
     private final AtomicInteger lastAck = new AtomicInteger(0);
+    private final AtomicLong sentBytes = new AtomicLong(0);
+    private final AtomicLong receivedBytes = new AtomicLong(0);
 
     public ReliableUdpChannel() throws SocketException {
         this.socket = createSocket();
@@ -119,6 +126,13 @@ public class ReliableUdpChannel {
     public void registerStream(int streamId, OutputStream output) {
         outputs.put(streamId, output);
         reorderBuffers.computeIfAbsent(streamId, ignored -> new ReorderBuffer());
+        List<UdpPacketCodec.DecodedData> pending = pendingBeforeRegister.remove(streamId);
+        if (pending != null && !pending.isEmpty()) {
+            LOGGER.info("[FireflyMC] P2P 回放早到数据: stream={}, packets={}", streamId, pending.size());
+            pending.stream()
+                    .sorted(java.util.Comparator.comparingInt(UdpPacketCodec.DecodedData::seq))
+                    .forEach(decoded -> writeDecodedPayload(decoded, output));
+        }
     }
 
     public void unregisterStream(int streamId) {
@@ -136,7 +150,15 @@ public class ReliableUdpChannel {
             int chunk = Math.min(UdpPacketCodec.MAX_PAYLOAD_SIZE, length - offset);
             byte[] payload = Arrays.copyOfRange(bytes, offset, offset + chunk);
             int seq = nextSeq.getAndIncrement();
-            send(peer, UdpPacketCodec.data(streamId, seq, lastAck.get(), (byte) 0, payload, payload.length));
+            byte[] packet = UdpPacketCodec.data(streamId, seq, lastAck.get(), (byte) 0, payload, payload.length);
+            send(peer, packet);
+            // Temporary redundancy until full retransmit queue is implemented.
+            send(peer, packet);
+            sentBytes.addAndGet(payload.length);
+            if (sentBytes.get() <= 8192 || payload.length > 1000) {
+                LOGGER.info("[FireflyMC] P2P UDP 发送数据: stream={}, seq={}, bytes={}, total={} KB, peer={}",
+                        streamId, seq, payload.length, sentBytes.get() / 1024, peer);
+            }
             offset += chunk;
         }
     }
@@ -200,16 +222,35 @@ public class ReliableUdpChannel {
         lastAck.set(Math.max(lastAck.get(), decoded.seq()));
         OutputStream output = outputs.get(decoded.streamId());
         if (output != null && decoded.payload().length > 0) {
-            try {
+            writeDecodedPayload(decoded, output);
+            InetSocketAddress peer = peerAddress;
+            if (peer != null) {
                 ReorderBuffer reorder = reorderBuffers.computeIfAbsent(decoded.streamId(), ignored -> new ReorderBuffer());
-                reorder.accept(decoded.seq(), decoded.payload(), output);
-                InetSocketAddress peer = peerAddress;
-                if (peer != null) {
-                    send(peer, UdpPacketCodec.ack(decoded.streamId(), reorder.ackSeq()));
-                }
-            } catch (IOException e) {
-                LOGGER.debug("[FireflyMC] P2P stream write failed: {}", e.getMessage());
+                send(peer, UdpPacketCodec.ack(decoded.streamId(), reorder.ackSeq()));
             }
+        } else if (decoded.payload().length > 0) {
+            List<UdpPacketCodec.DecodedData> pending = pendingBeforeRegister.computeIfAbsent(
+                    decoded.streamId(), ignored -> Collections.synchronizedList(new ArrayList<>())
+            );
+            if (pending.size() < 256) {
+                pending.add(decoded);
+                LOGGER.info("[FireflyMC] P2P 缓存早到数据: stream={}, seq={}, bytes={}, pending={}",
+                        decoded.streamId(), decoded.seq(), decoded.payload().length, pending.size());
+            }
+        }
+    }
+
+    private void writeDecodedPayload(UdpPacketCodec.DecodedData decoded, OutputStream output) {
+        try {
+            ReorderBuffer reorder = reorderBuffers.computeIfAbsent(decoded.streamId(), ignored -> new ReorderBuffer());
+            reorder.accept(decoded.seq(), decoded.payload(), output);
+            receivedBytes.addAndGet(decoded.payload().length);
+            if (receivedBytes.get() <= 8192 || decoded.payload().length > 1000) {
+                LOGGER.info("[FireflyMC] P2P UDP 接收数据: stream={}, seq={}, bytes={}, total={} KB",
+                        decoded.streamId(), decoded.seq(), decoded.payload().length, receivedBytes.get() / 1024);
+            }
+        } catch (IOException e) {
+            LOGGER.debug("[FireflyMC] P2P stream write failed: {}", e.getMessage());
         }
     }
 

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
@@ -42,6 +42,8 @@ public class ReliableUdpChannel {
     private volatile InetSocketAddress peerAddress;
     private volatile boolean observedByServer;
     private volatile boolean punchedPeer;
+    private volatile boolean loggedObserved;
+    private volatile boolean loggedPunch;
     private final Map<Integer, OutputStream> outputs = new ConcurrentHashMap<>();
     private final Map<Integer, ReorderBuffer> reorderBuffers = new ConcurrentHashMap<>();
     private final AtomicInteger nextSeq = new AtomicInteger(1);
@@ -71,14 +73,14 @@ public class ReliableUdpChannel {
         if (!receiverThread.isAlive()) {
             receiverThread.start();
         }
-        InetSocketAddress serverAddress = new InetSocketAddress(info.udpHost(), info.udpPort());
+        InetSocketAddress serverAddress = new InetSocketAddress(info.effectiveUdpHost(), info.udpPort());
         int timeout = info.timeoutSeconds() > 0
                 ? info.timeoutSeconds()
                 : Config.CLIENT.SINGLEPLAYER_RELAY_P2P_CONNECT_TIMEOUT_SECONDS.get();
         byte[] probe = UdpPacketCodec.probe(info.roomId(), info.guestSessionId(), role, info.p2pToken());
         byte[] punch = UdpPacketCodec.punch(info.roomId(), info.guestSessionId(), role, info.p2pToken());
-        LOGGER.info("[FireflyMC] P2P {} 开始探测: server={}, localUdp={}, timeout={}s",
-            role, serverAddress, localPort(), timeout);
+        LOGGER.info("[FireflyMC] P2P {} 开始探测: server={}, localUdp={}, timeout={}s, rawUdpHost={}",
+            role, serverAddress, localPort(), timeout, info.udpHost());
         ScheduledFuture<?> probeTask = executor.scheduleAtFixedRate(() -> {
             send(serverAddress, probe);
             InetSocketAddress peer = peerAddress;
@@ -166,11 +168,17 @@ public class ReliableUdpChannel {
                 String text = new String(packet.getData(), packet.getOffset(), packet.getLength());
                 if (text.contains("probe_ack")) {
                     observedByServer = true;
-                    LOGGER.info("[FireflyMC] P2P 已被服务端观测到: {}", text);
+                    if (!loggedObserved) {
+                        loggedObserved = true;
+                        LOGGER.info("[FireflyMC] P2P 已被服务端观测到: {}", text);
+                    }
                 } else if (text.contains("punch")) {
                     punchedPeer = true;
                     peerAddress = new InetSocketAddress(packet.getAddress(), packet.getPort());
-                    LOGGER.info("[FireflyMC] P2P 收到对端 punch: {}", peerAddress);
+                    if (!loggedPunch) {
+                        loggedPunch = true;
+                        LOGGER.info("[FireflyMC] P2P 收到对端 punch: {}", peerAddress);
+                    }
                 }
             } catch (IOException e) {
                 if (running.get()) {

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/ReliableUdpChannel.java
@@ -58,6 +58,8 @@ public class ReliableUdpChannel {
     private final AtomicLong nextSentLogAt = new AtomicLong(64 * 1024);
     private final AtomicLong nextReceivedLogAt = new AtomicLong(64 * 1024);
     private final SendWindow sendWindow;
+    private volatile long lastReceivedAt = System.currentTimeMillis();
+    private static final long PEER_IDLE_TIMEOUT_MS = 30_000;
 
     public ReliableUdpChannel() throws SocketException {
         this.socket = createSocket();
@@ -101,6 +103,7 @@ public class ReliableUdpChannel {
             if (observedByServer && punchedPeer && !result.isDone()) {
                 LOGGER.info("[FireflyMC] P2P {} 打洞完成: peer={}", role, peerAddress);
                 sendWindow.start();
+                startIdleCheck();
                 result.complete(true);
             }
         }, 0, 300, TimeUnit.MILLISECONDS);
@@ -147,7 +150,7 @@ public class ReliableUdpChannel {
 
     public void sendData(int streamId, byte[] bytes, int length) {
         InetSocketAddress peer = peerAddress;
-        if (peer == null || length <= 0) {
+        if (peer == null || length <= 0 || !running.get()) {
             return;
         }
         int offset = 0;
@@ -171,16 +174,34 @@ public class ReliableUdpChannel {
 
     public void sendFin(int streamId) {
         InetSocketAddress peer = peerAddress;
-        if (peer != null) {
+        if (peer != null && running.get()) {
             send(peer, UdpPacketCodec.fin(streamId, nextSeq.getAndIncrement(), lastAck.get()));
         }
     }
 
+    public boolean isRunning() {
+        return running.get() && !socket.isClosed();
+    }
+
     public void close() {
-        running.set(false);
+        if (!running.compareAndSet(true, false)) {
+            return;
+        }
+        LOGGER.info("[FireflyMC] P2P UDP channel closing: localPort={}", socket.getLocalPort());
         sendWindow.close();
         socket.close();
         executor.shutdownNow();
+    }
+
+    private void startIdleCheck() {
+        executor.scheduleAtFixedRate(() -> {
+            if (!running.get()) return;
+            long idle = System.currentTimeMillis() - lastReceivedAt;
+            if (idle > PEER_IDLE_TIMEOUT_MS) {
+                LOGGER.warn("[FireflyMC] P2P peer idle timeout ({}ms), closing channel", idle);
+                close();
+            }
+        }, 5, 5, TimeUnit.SECONDS);
     }
 
     private void receiveLoop() {
@@ -191,6 +212,7 @@ public class ReliableUdpChannel {
                 socket.receive(packet);
                 byte[] packetBytes = Arrays.copyOfRange(packet.getData(), packet.getOffset(), packet.getOffset() + packet.getLength());
                 if (UdpPacketCodec.isBinaryData(packetBytes)) {
+                    lastReceivedAt = System.currentTimeMillis();
                     handleDataPacket(packetBytes, packet);
                     continue;
                 }
@@ -203,6 +225,7 @@ public class ReliableUdpChannel {
                     }
                 } else if (text.contains("punch")) {
                     punchedPeer = true;
+                    lastReceivedAt = System.currentTimeMillis();
                     peerAddress = new InetSocketAddress(packet.getAddress(), packet.getPort());
                     if (!loggedPunch) {
                         loggedPunch = true;

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/ReorderBuffer.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/ReorderBuffer.java
@@ -1,0 +1,36 @@
+package firefly520.fireflymc.client.relay.p2p;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.TreeMap;
+
+final class ReorderBuffer {
+    private int expectedSeq = 1;
+    private final Map<Integer, byte[]> pending = new TreeMap<>();
+
+    synchronized void accept(int seq, byte[] payload, OutputStream output) throws IOException {
+        if (seq < expectedSeq) {
+            return;
+        }
+        if (seq == expectedSeq) {
+            output.write(payload);
+            expectedSeq++;
+            while (true) {
+                byte[] next = pending.remove(expectedSeq);
+                if (next == null) {
+                    break;
+                }
+                output.write(next);
+                expectedSeq++;
+            }
+            output.flush();
+            return;
+        }
+        pending.putIfAbsent(seq, payload);
+    }
+
+    synchronized int ackSeq() {
+        return expectedSeq - 1;
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/SendWindow.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/SendWindow.java
@@ -1,0 +1,102 @@
+package firefly520.fireflymc.client.relay.p2p;
+
+import firefly520.fireflymc.Config;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Sliding window sender with ACK-based retransmission.
+ * Tracks sent packets and retransmits those not acknowledged within a timeout.
+ */
+final class SendWindow {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SendWindow.class);
+    private static final int MAX_WINDOW = 128;
+
+    private final Map<Integer, SentPacket> unacked = new ConcurrentHashMap<>();
+    private final AtomicInteger lastAckedSeq = new AtomicInteger(0);
+    private final ScheduledExecutorService executor;
+    private final UdpSender sender;
+    private ScheduledFuture<?> retransmitTask;
+    private volatile boolean closed;
+
+    interface UdpSender {
+        void send(InetSocketAddress target, byte[] packet);
+    }
+
+    SendWindow(ScheduledExecutorService executor, UdpSender sender) {
+        this.executor = executor;
+        this.sender = sender;
+    }
+
+    void start() {
+        int retransmitMs = Config.CLIENT.SINGLEPLAYER_RELAY_P2P_RETRANSMIT_MILLIS.get();
+        retransmitTask = executor.scheduleAtFixedRate(this::retransmit, retransmitMs, retransmitMs, TimeUnit.MILLISECONDS);
+    }
+
+    void record(int seq, byte[] packet, InetSocketAddress target) {
+        if (closed) return;
+        unacked.put(seq, new SentPacket(packet, target, System.currentTimeMillis()));
+        // Evict very old packets to prevent memory leak
+        if (unacked.size() > MAX_WINDOW * 4) {
+            int cutoff = lastAckedSeq.get() - MAX_WINDOW;
+            unacked.entrySet().removeIf(e -> e.getKey() < cutoff);
+        }
+    }
+
+    void acknowledge(int ackSeq) {
+        if (ackSeq <= 0) return;
+        lastAckedSeq.set(Math.max(lastAckedSeq.get(), ackSeq));
+        // Remove all packets with seq <= ackSeq
+        unacked.entrySet().removeIf(e -> e.getKey() <= ackSeq);
+    }
+
+    int pendingCount() {
+        return unacked.size();
+    }
+
+    void close() {
+        closed = true;
+        if (retransmitTask != null) {
+            retransmitTask.cancel(false);
+        }
+        unacked.clear();
+    }
+
+    private void retransmit() {
+        if (closed || unacked.isEmpty()) return;
+        long now = System.currentTimeMillis();
+        int retransmitMs = Config.CLIENT.SINGLEPLAYER_RELAY_P2P_RETRANSMIT_MILLIS.get();
+        int retransmitted = 0;
+        for (SentPacket sp : unacked.values()) {
+            if (now - sp.sentAt >= retransmitMs) {
+                sender.send(sp.target, sp.packet);
+                sp.sentAt = now;
+                retransmitted++;
+            }
+        }
+        if (retransmitted > 0) {
+            LOGGER.debug("[FireflyMC] P2P 重传: {} packets, pending={}", retransmitted, unacked.size());
+        }
+    }
+
+    private static class SentPacket {
+        final byte[] packet;
+        final InetSocketAddress target;
+        volatile long sentAt;
+
+        SentPacket(byte[] packet, InetSocketAddress target, long sentAt) {
+            this.packet = packet;
+            this.target = target;
+            this.sentAt = sentAt;
+        }
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/UdpPacketCodec.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/UdpPacketCodec.java
@@ -17,6 +17,9 @@ public final class UdpPacketCodec {
     public static final String MAGIC = "fireflymc-p2p";
     public static final int PROTOCOL_VERSION = 1;
     public static final int MAX_PAYLOAD_SIZE = 1200;
+    public static final byte FLAG_ACK = 1;
+    public static final byte FLAG_FIN = 2;
+    public static final byte FLAG_RST = 4;
     private static final int BINARY_MAGIC = 0x46465032; // FFP2
     private static final Gson GSON = new Gson();
 
@@ -60,6 +63,21 @@ public final class UdpPacketCodec {
         buffer.putShort((short) safeLength);
         buffer.put(payload, 0, safeLength);
         return buffer.array();
+    }
+
+    public static byte[] ack(int streamId, int ack) {
+        return data(streamId, 0, ack, FLAG_ACK, new byte[0], 0);
+    }
+
+    public static byte[] fin(int streamId, int seq, int ack) {
+        return data(streamId, seq, ack, FLAG_FIN, new byte[0], 0);
+    }
+
+    public static boolean isBinaryData(byte[] packet) {
+        if (packet.length < 4) {
+            return false;
+        }
+        return ByteBuffer.wrap(packet, 0, 4).getInt() == BINARY_MAGIC;
     }
 
     public static DecodedData decodeData(byte[] packet) {

--- a/src/main/java/firefly520/fireflymc/client/relay/p2p/UdpPacketCodec.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/p2p/UdpPacketCodec.java
@@ -1,0 +1,93 @@
+package firefly520.fireflymc.client.relay.p2p;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Minimal packet codec for the first P2P MVP.
+ *
+ * <p>Probe/punch packets are JSON for easy interoperability with the AstrBot relay.
+ * Reliable data packets use a compact binary header and are intentionally kept small
+ * to avoid IP fragmentation.</p>
+ */
+public final class UdpPacketCodec {
+    public static final String MAGIC = "fireflymc-p2p";
+    public static final int PROTOCOL_VERSION = 1;
+    public static final int MAX_PAYLOAD_SIZE = 1200;
+    private static final int BINARY_MAGIC = 0x46465032; // FFP2
+    private static final Gson GSON = new Gson();
+
+    private UdpPacketCodec() {
+    }
+
+    public static byte[] probe(String roomId, String guestSessionId, String role, String token) {
+        JsonObject json = new JsonObject();
+        json.addProperty("magic", MAGIC);
+        json.addProperty("type", "probe");
+        json.addProperty("version", PROTOCOL_VERSION);
+        json.addProperty("roomId", roomId);
+        json.addProperty("guestSessionId", guestSessionId);
+        json.addProperty("role", role);
+        json.addProperty("p2pToken", token);
+        return GSON.toJson(json).getBytes(StandardCharsets.UTF_8);
+    }
+
+    public static byte[] punch(String roomId, String guestSessionId, String role, String token) {
+        JsonObject json = new JsonObject();
+        json.addProperty("magic", MAGIC);
+        json.addProperty("type", "punch");
+        json.addProperty("version", PROTOCOL_VERSION);
+        json.addProperty("roomId", roomId);
+        json.addProperty("guestSessionId", guestSessionId);
+        json.addProperty("role", role);
+        json.addProperty("p2pToken", token);
+        return GSON.toJson(json).getBytes(StandardCharsets.UTF_8);
+    }
+
+    public static byte[] data(int streamId, int seq, int ack, byte flags, byte[] payload, int length) {
+        int safeLength = Math.min(length, MAX_PAYLOAD_SIZE);
+        ByteBuffer buffer = ByteBuffer.allocate(21 + safeLength);
+        buffer.putInt(BINARY_MAGIC);
+        buffer.put((byte) PROTOCOL_VERSION);
+        buffer.put((byte) 1); // data
+        buffer.putInt(streamId);
+        buffer.putInt(seq);
+        buffer.putInt(ack);
+        buffer.put(flags);
+        buffer.putShort((short) safeLength);
+        buffer.put(payload, 0, safeLength);
+        return buffer.array();
+    }
+
+    public static DecodedData decodeData(byte[] packet) {
+        if (packet.length < 21) {
+            return null;
+        }
+        ByteBuffer buffer = ByteBuffer.wrap(packet);
+        if (buffer.getInt() != BINARY_MAGIC) {
+            return null;
+        }
+        int version = Byte.toUnsignedInt(buffer.get());
+        int type = Byte.toUnsignedInt(buffer.get());
+        if (version != PROTOCOL_VERSION || type != 1) {
+            return null;
+        }
+        int streamId = buffer.getInt();
+        int seq = buffer.getInt();
+        int ack = buffer.getInt();
+        byte flags = buffer.get();
+        int length = Short.toUnsignedInt(buffer.getShort());
+        if (length > buffer.remaining()) {
+            return null;
+        }
+        byte[] payload = new byte[length];
+        buffer.get(payload);
+        return new DecodedData(streamId, seq, ack, flags, payload);
+    }
+
+    public record DecodedData(int streamId, int seq, int ack, byte flags, byte[] payload) {
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/screen/RelayLobbyScreen.java
+++ b/src/main/java/firefly520/fireflymc/client/screen/RelayLobbyScreen.java
@@ -15,8 +15,6 @@ import java.util.List;
 
 /**
  * FireflyMC 单人世界公开大厅。
- *
- * 当前阶段展示房间列表；点击加入会提示后续实现 guest_join / 本地代理。
  */
 public class RelayLobbyScreen extends Screen {
     private static final int ACCENT_PRIMARY = 0xFFFF69B4;

--- a/src/main/java/firefly520/fireflymc/client/screen/RelayLobbyScreen.java
+++ b/src/main/java/firefly520/fireflymc/client/screen/RelayLobbyScreen.java
@@ -1,0 +1,244 @@
+package firefly520.fireflymc.client.screen;
+
+import firefly520.fireflymc.client.relay.RelayLobbyRoom;
+import firefly520.fireflymc.client.relay.RelayLobbyState;
+import firefly520.fireflymc.client.relay.RelayLobbyWebSocketClient;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+import javax.annotation.Nonnull;
+import java.util.List;
+
+/**
+ * FireflyMC 单人世界公开大厅。
+ *
+ * 当前阶段展示房间列表；点击加入会提示后续实现 guest_join / 本地代理。
+ */
+public class RelayLobbyScreen extends Screen {
+    private static final int ACCENT_PRIMARY = 0xFFFF69B4;
+    private static final int ACCENT_SECONDARY = 0xFFFF1493;
+    private static final int TEXT_PRIMARY = 0xFF2D2D2D;
+    private static final int TEXT_SECONDARY = 0xFF666666;
+    private static final int SHADOW_LIGHT = 0x30FFFFFF;
+    private static final int SHADOW_DARK = 0x40000000;
+
+    private final Screen parent;
+
+    public RelayLobbyScreen(Screen parent) {
+        super(Component.literal("FireflyMC 联机大厅"));
+        this.parent = parent;
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+
+        int buttonWidth = 90;
+        int buttonHeight = 24;
+        int y = this.height - 48;
+        int centerX = this.width / 2;
+
+        this.addRenderableWidget(Button.builder(
+                Component.literal("刷新"),
+                button -> RelayLobbyWebSocketClient.getInstance().requestLobbyList()
+        ).bounds(centerX - buttonWidth - 8, y, buttonWidth, buttonHeight).build());
+
+        this.addRenderableWidget(Button.builder(
+                Component.literal("返回"),
+                button -> onClose()
+        ).bounds(centerX + 8, y, buttonWidth, buttonHeight).build());
+
+        RelayLobbyWebSocketClient.getInstance().requestLobbyList();
+    }
+
+    @Override
+    public void renderBackground(@Nonnull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        // 与公告弹窗一致：不调用默认背景
+    }
+
+    @Override
+    public void render(@Nonnull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        int dialogWidth = Math.min(560, this.width - 40);
+        int dialogHeight = Math.min(420, this.height - 80);
+        int dialogX = (this.width - dialogWidth) / 2;
+        int dialogY = (this.height - dialogHeight) / 2;
+
+        drawRoundedRect(guiGraphics, dialogX + 6, dialogY + 6, dialogWidth, dialogHeight, 10, SHADOW_DARK);
+        drawFrostedGlassBackground(guiGraphics, dialogX, dialogY, dialogWidth, dialogHeight, 10);
+        drawGradientBorder(guiGraphics, dialogX, dialogY, dialogWidth, dialogHeight, 10);
+
+        Component title = Component.literal("FireflyMC 公开单人世界");
+        int titleX = this.width / 2 - this.font.width(title) / 2;
+        guiGraphics.drawString(this.font, title.getVisualOrderText(), titleX, dialogY + 20, ACCENT_SECONDARY, false);
+        drawStarIcon(guiGraphics, titleX - 18, dialogY + 22, ACCENT_PRIMARY);
+        drawStarIcon(guiGraphics, titleX + this.font.width(title) + 14, dialogY + 22, ACCENT_PRIMARY);
+
+        int separatorY = dialogY + 52;
+        drawGradientLine(guiGraphics, dialogX + 20, separatorY, dialogX + dialogWidth - 20, separatorY,
+                ACCENT_PRIMARY, ACCENT_SECONDARY);
+
+        String status = RelayLobbyState.isRefreshing() ? "正在刷新公开大厅..." : RelayLobbyState.statusMessage();
+        drawCentered(guiGraphics, status, separatorY + 16, TEXT_SECONDARY);
+
+        List<RelayLobbyRoom> rooms = RelayLobbyState.rooms();
+        int listX = dialogX + 28;
+        int listY = separatorY + 44;
+        int rowWidth = dialogWidth - 56;
+        int rowHeight = 46;
+
+        if (rooms.isEmpty()) {
+            drawCentered(guiGraphics, "暂无可加入的公开单人世界", listY + 36, TEXT_SECONDARY);
+        } else {
+            for (int i = 0; i < Math.min(rooms.size(), 6); i++) {
+                RelayLobbyRoom room = rooms.get(i);
+                int rowY = listY + i * (rowHeight + 8);
+                drawRoomRow(guiGraphics, room, listX, rowY, rowWidth, rowHeight, mouseX, mouseY);
+            }
+        }
+
+        super.render(guiGraphics, mouseX, mouseY, partialTick);
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        if (button == 0) {
+            RelayLobbyRoom clicked = getRoomAt(mouseX, mouseY);
+            if (clicked != null) {
+                RelayLobbyState.setStatusMessage("加入房间将在下一阶段接入: " + clicked.worldName());
+                return true;
+            }
+        }
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    @Override
+    public void onClose() {
+        Minecraft.getInstance().setScreen(parent);
+    }
+
+    private RelayLobbyRoom getRoomAt(double mouseX, double mouseY) {
+        int dialogWidth = Math.min(560, this.width - 40);
+        int dialogHeight = Math.min(420, this.height - 80);
+        int dialogX = (this.width - dialogWidth) / 2;
+        int dialogY = (this.height - dialogHeight) / 2;
+        int listX = dialogX + 28;
+        int listY = dialogY + 52 + 44;
+        int rowWidth = dialogWidth - 56;
+        int rowHeight = 46;
+
+        List<RelayLobbyRoom> rooms = RelayLobbyState.rooms();
+        for (int i = 0; i < Math.min(rooms.size(), 6); i++) {
+            int rowY = listY + i * (rowHeight + 8);
+            if (mouseX >= listX && mouseX <= listX + rowWidth && mouseY >= rowY && mouseY <= rowY + rowHeight) {
+                return rooms.get(i);
+            }
+        }
+        return null;
+    }
+
+    private void drawRoomRow(GuiGraphics guiGraphics, RelayLobbyRoom room, int x, int y, int width, int height, int mouseX, int mouseY) {
+        boolean hovered = mouseX >= x && mouseX <= x + width && mouseY >= y && mouseY <= y + height;
+        int bgColor = hovered ? 0x60FFFFFF : 0x35FFFFFF;
+        drawRoundedRect(guiGraphics, x, y, width, height, 6, bgColor);
+        drawRoundedRect(guiGraphics, x, y, 4, height, 3, ACCENT_PRIMARY);
+
+        guiGraphics.drawString(this.font, room.worldName(), x + 14, y + 8, TEXT_PRIMARY, false);
+        guiGraphics.drawString(this.font, "房主: " + room.hostPlayerName(), x + 14, y + 26, TEXT_SECONDARY, false);
+
+        String players = room.currentPlayers() + "/" + room.maxPlayers();
+        guiGraphics.drawString(this.font, players, x + width - this.font.width(players) - 14, y + 8, ACCENT_SECONDARY, false);
+
+        String version = "MC " + room.minecraftVersion() + " / Mod " + room.modVersion();
+        guiGraphics.drawString(this.font, version, x + width - this.font.width(version) - 14, y + 26, TEXT_SECONDARY, false);
+    }
+
+    private void drawCentered(GuiGraphics guiGraphics, String text, int y, int color) {
+        guiGraphics.drawString(this.font, text, this.width / 2 - this.font.width(text) / 2, y, color, false);
+    }
+
+    private void drawRoundedRect(GuiGraphics guiGraphics, int x, int y, int width, int height, int radius, int color) {
+        guiGraphics.fill(x + radius, y, x + width - radius, y + height, color);
+        guiGraphics.fill(x, y + radius, x + width, y + height - radius, color);
+        guiGraphics.fill(x + radius, y, x + width - radius, y + radius, color);
+        guiGraphics.fill(x + radius, y + height - radius, x + width - radius, y + height, color);
+        fillCircle(guiGraphics, x + radius, y + radius, radius, color);
+        fillCircle(guiGraphics, x + width - radius, y + radius, radius, color);
+        fillCircle(guiGraphics, x + radius, y + height - radius, radius, color);
+        fillCircle(guiGraphics, x + width - radius, y + height - radius, radius, color);
+    }
+
+    private void fillCircle(GuiGraphics guiGraphics, int centerX, int centerY, int radius, int color) {
+        for (int i = -radius; i <= radius; i++) {
+            for (int j = -radius; j <= radius; j++) {
+                if (i * i + j * j <= radius * radius) {
+                    guiGraphics.fill(centerX + i, centerY + j, centerX + i + 1, centerY + j + 1, color);
+                }
+            }
+        }
+    }
+
+    private void drawFrostedGlassBackground(GuiGraphics guiGraphics, int x, int y, int width, int height, int radius) {
+        drawRoundedRect(guiGraphics, x, y, width, height, radius, 0xDDFAFAFA);
+        drawRoundedRect(guiGraphics, x + 1, y + 1, width - 2, height - 2, radius - 1, 0x40FFFFFF);
+        drawRoundedRect(guiGraphics, x + 2, y + 2, width - 4, height / 2 - 2, radius - 2, SHADOW_LIGHT);
+    }
+
+    private void drawGradientBorder(GuiGraphics guiGraphics, int x, int y, int width, int height, int radius) {
+        for (int i = 0; i < 3; i++) {
+            float ratio = i / 2f;
+            int color = lerpColor(ACCENT_PRIMARY, ACCENT_SECONDARY, ratio);
+            guiGraphics.fill(x + radius, y + i, x + width - radius, y + i + 1, color);
+        }
+        for (int i = 0; i < 3; i++) {
+            float ratio = i / 2f;
+            int color = lerpColor(ACCENT_SECONDARY, ACCENT_PRIMARY, ratio);
+            guiGraphics.fill(x + radius, y + height - 3 + i, x + width - radius, y + height - 2 + i, color);
+        }
+        for (int i = 0; i < 3; i++) {
+            guiGraphics.fill(x + i, y + radius, x + i + 1, y + height - radius, ACCENT_PRIMARY);
+        }
+        for (int i = 0; i < 3; i++) {
+            guiGraphics.fill(x + width - 3 + i, y + radius, x + width - 2 + i, y + height - radius, ACCENT_SECONDARY);
+        }
+    }
+
+    private void drawGradientLine(GuiGraphics guiGraphics, int x1, int y, int x2, int y2, int color1, int color2) {
+        int length = x2 - x1;
+        for (int i = 0; i < length; i++) {
+            float ratio = i / (float)length;
+            int color = lerpColor(color1, color2, ratio);
+            guiGraphics.fill(x1 + i, y, x1 + i + 1, y + 1, color);
+        }
+    }
+
+    private void drawStarIcon(GuiGraphics guiGraphics, int x, int y, int color) {
+        guiGraphics.fill(x + 4, y, x + 6, y + 1, color);
+        guiGraphics.fill(x + 3, y + 1, x + 7, y + 2, color);
+        guiGraphics.fill(x + 2, y + 2, x + 8, y + 3, color);
+        guiGraphics.fill(x + 1, y + 3, x + 9, y + 4, color);
+        guiGraphics.fill(x + 2, y + 4, x + 8, y + 5, color);
+        guiGraphics.fill(x + 3, y + 5, x + 7, y + 6, color);
+        guiGraphics.fill(x + 4, y + 6, x + 6, y + 7, color);
+        guiGraphics.fill(x + 3, y + 7, x + 4, y + 8, color);
+        guiGraphics.fill(x + 5, y + 7, x + 6, y + 8, color);
+    }
+
+    private int lerpColor(int color1, int color2, float ratio) {
+        int a1 = (color1 >> 24) & 0xFF;
+        int r1 = (color1 >> 16) & 0xFF;
+        int g1 = (color1 >> 8) & 0xFF;
+        int b1 = color1 & 0xFF;
+        int a2 = (color2 >> 24) & 0xFF;
+        int r2 = (color2 >> 16) & 0xFF;
+        int g2 = (color2 >> 8) & 0xFF;
+        int b2 = color2 & 0xFF;
+        int a = (int)(a1 + (a2 - a1) * ratio);
+        int r = (int)(r1 + (r2 - r1) * ratio);
+        int g = (int)(g1 + (g2 - g1) * ratio);
+        int b = (int)(b1 + (b2 - b1) * ratio);
+        return (a << 24) | (r << 16) | (g << 8) | b;
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/screen/RelayLobbyScreen.java
+++ b/src/main/java/firefly520/fireflymc/client/screen/RelayLobbyScreen.java
@@ -147,7 +147,7 @@ public class RelayLobbyScreen extends Screen {
         guiGraphics.drawString(this.font, room.worldName(), x + 14, y + 8, TEXT_PRIMARY, false);
         guiGraphics.drawString(this.font, "房主: " + room.hostPlayerName(), x + 14, y + 26, TEXT_SECONDARY, false);
 
-        String players = room.currentPlayers() + "/" + room.maxPlayers();
+        String players = (room.p2pSupported() ? "P2P优先  " : "中继  ") + room.currentPlayers() + "/" + room.maxPlayers();
         guiGraphics.drawString(this.font, players, x + width - this.font.width(players) - 14, y + 8, ACCENT_SECONDARY, false);
 
         String version = "MC " + room.minecraftVersion() + " / Mod " + room.modVersion();

--- a/src/main/java/firefly520/fireflymc/client/screen/RelayLobbyScreen.java
+++ b/src/main/java/firefly520/fireflymc/client/screen/RelayLobbyScreen.java
@@ -3,6 +3,7 @@ package firefly520.fireflymc.client.screen;
 import firefly520.fireflymc.client.relay.RelayLobbyRoom;
 import firefly520.fireflymc.client.relay.RelayLobbyState;
 import firefly520.fireflymc.client.relay.RelayLobbyWebSocketClient;
+import firefly520.fireflymc.client.relay.RelayGuestJoiner;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.components.Button;
@@ -107,7 +108,7 @@ public class RelayLobbyScreen extends Screen {
         if (button == 0) {
             RelayLobbyRoom clicked = getRoomAt(mouseX, mouseY);
             if (clicked != null) {
-                RelayLobbyState.setStatusMessage("加入房间将在下一阶段接入: " + clicked.worldName());
+                RelayGuestJoiner.join(this, clicked);
                 return true;
             }
         }

--- a/src/main/java/firefly520/fireflymc/client/screen/SingleplayerSharePromptScreen.java
+++ b/src/main/java/firefly520/fireflymc/client/screen/SingleplayerSharePromptScreen.java
@@ -1,0 +1,220 @@
+package firefly520.fireflymc.client.screen;
+
+import firefly520.fireflymc.Config;
+import firefly520.fireflymc.client.ClientState;
+import firefly520.fireflymc.client.relay.SingleplayerRelayManager;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+import javax.annotation.Nonnull;
+
+/**
+ * 单人世界公开联机确认弹窗。
+ *
+ * 阶段一仅负责用户确认、调用 openToLAN 并展示 LAN 端口；公开大厅和中继将在后续阶段接入。
+ */
+public class SingleplayerSharePromptScreen extends Screen {
+    private static final int ACCENT_PRIMARY = 0xFFFF69B4;
+    private static final int ACCENT_SECONDARY = 0xFFFF1493;
+    private static final int TEXT_PRIMARY = 0xFF2D2D2D;
+    private static final int TEXT_SECONDARY = 0xFF666666;
+    private static final int WARNING_COLOR = 0xFFFFAA00;
+    private static final int SHADOW_LIGHT = 0x30FFFFFF;
+    private static final int SHADOW_DARK = 0x40000000;
+
+    private final Screen parent;
+    private final String worldName;
+
+    public SingleplayerSharePromptScreen(Screen parent, String worldName) {
+        super(Component.literal("单人世界联机"));
+        this.parent = parent;
+        this.worldName = worldName == null || worldName.isBlank() ? "我的单人世界" : worldName;
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+
+        int buttonWidth = 140;
+        int buttonHeight = 24;
+        int spacing = 12;
+        int totalWidth = buttonWidth * 2 + spacing;
+        int startX = this.width / 2 - totalWidth / 2;
+        int dialogHeight = Math.min(300, this.height - 80);
+        int dialogY = (this.height - dialogHeight) / 2;
+        int y = dialogY + dialogHeight - 54;
+
+        this.addRenderableWidget(Button.builder(
+                Component.literal("§a开启联机"),
+                button -> onStartHosting()
+        ).bounds(startX, y, buttonWidth, buttonHeight).build());
+
+        this.addRenderableWidget(Button.builder(
+                Component.literal("§7暂不开启"),
+                button -> onSkip()
+        ).bounds(startX + buttonWidth + spacing, y, buttonWidth, buttonHeight).build());
+    }
+
+    // 与公告弹窗一致：不调用默认背景，避免额外遮罩/层级覆盖
+    @Override
+    public void renderBackground(@Nonnull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        // 不调用 super.renderBackground()
+    }
+
+    @Override
+    public void render(@Nonnull GuiGraphics guiGraphics, int mouseX, int mouseY, float partialTick) {
+        int dialogWidth = Math.min(520, this.width - 40);
+        int dialogHeight = Math.min(300, this.height - 80);
+        int dialogX = (this.width - dialogWidth) / 2;
+        int dialogY = (this.height - dialogHeight) / 2;
+
+        // 复用公告弹窗风格：阴影 + 毛玻璃 + 渐变边框，全部在 widget 前绘制
+        drawRoundedRect(guiGraphics, dialogX + 6, dialogY + 6, dialogWidth, dialogHeight, 10, SHADOW_DARK);
+        drawFrostedGlassBackground(guiGraphics, dialogX, dialogY, dialogWidth, dialogHeight, 10);
+        drawGradientBorder(guiGraphics, dialogX, dialogY, dialogWidth, dialogHeight, 10);
+
+        Component title = Component.literal("FireflyMC 单人世界联机");
+        int titleX = this.width / 2 - this.font.width(title) / 2;
+        guiGraphics.drawString(this.font, title.getVisualOrderText(),
+                (float)titleX, (float)(dialogY + 20), ACCENT_SECONDARY, false);
+
+        drawStarIcon(guiGraphics, titleX - 18, dialogY + 22, ACCENT_PRIMARY);
+        drawStarIcon(guiGraphics, titleX + this.font.width(title) + 14, dialogY + 22, ACCENT_PRIMARY);
+
+        int separatorY = dialogY + 52;
+        drawGradientLine(guiGraphics, dialogX + 20, separatorY, dialogX + dialogWidth - 20, separatorY,
+                ACCENT_PRIMARY, ACCENT_SECONDARY);
+
+        drawCentered(guiGraphics, "是否将当前单人世界公开到 FireflyMC 联机大厅？", separatorY + 22, TEXT_PRIMARY);
+        drawCentered(guiGraphics, "公开名称：" + worldName, separatorY + 44, ACCENT_PRIMARY);
+
+        int textX = dialogX + 34;
+        int textY = separatorY + 78;
+        guiGraphics.drawString(this.font, "开启后，其他安装 FireflyMC 的玩家将可在多人列表看到并加入。", textX, textY, TEXT_SECONDARY, false);
+        guiGraphics.drawString(this.font, "阶段一会先打开本机 LAN 端口并记录端口，暂不接入中继大厅。", textX, textY + 18, TEXT_SECONDARY, false);
+        guiGraphics.drawString(this.font, "请注意：公开房间后陌生玩家可能进入并影响你的存档。", textX, textY + 36, WARNING_COLOR, false);
+
+        int port = ClientState.singleplayerRelayLanPort;
+        if (ClientState.isSingleplayerRelayHosting && port > 0) {
+            drawCentered(guiGraphics, "LAN 已准备，端口：" + port, textY + 70, 0xFF228B22);
+        } else if (ClientState.isSingleplayerRelayHosting) {
+            drawCentered(guiGraphics, "LAN 已请求开启，正在等待端口读取", textY + 70, 0xFF228B22);
+        }
+
+        super.render(guiGraphics, mouseX, mouseY, partialTick);
+    }
+
+    @Override
+    public boolean shouldCloseOnEsc() {
+        return true;
+    }
+
+    @Override
+    public void onClose() {
+        Minecraft.getInstance().setScreen(parent);
+    }
+
+    private void onStartHosting() {
+        ClientState.hasHandledSingleplayerRelayPrompt = true;
+        SingleplayerRelayManager.getInstance().startHosting();
+        Minecraft.getInstance().setScreen(parent);
+    }
+
+    private void onSkip() {
+        ClientState.hasHandledSingleplayerRelayPrompt = true;
+        Minecraft.getInstance().setScreen(parent);
+    }
+
+    private void drawCentered(GuiGraphics guiGraphics, String text, int y, int color) {
+        guiGraphics.drawString(this.font, text, this.width / 2 - this.font.width(text) / 2, y, color, false);
+    }
+
+    private void drawRoundedRect(GuiGraphics guiGraphics, int x, int y, int width, int height, int radius, int color) {
+        guiGraphics.fill(x + radius, y, x + width - radius, y + height, color);
+        guiGraphics.fill(x, y + radius, x + width, y + height - radius, color);
+        guiGraphics.fill(x + radius, y, x + width - radius, y + radius, color);
+        guiGraphics.fill(x + radius, y + height - radius, x + width - radius, y + height, color);
+        fillCircle(guiGraphics, x + radius, y + radius, radius, color);
+        fillCircle(guiGraphics, x + width - radius, y + radius, radius, color);
+        fillCircle(guiGraphics, x + radius, y + height - radius, radius, color);
+        fillCircle(guiGraphics, x + width - radius, y + height - radius, radius, color);
+    }
+
+    private void fillCircle(GuiGraphics guiGraphics, int centerX, int centerY, int radius, int color) {
+        for (int i = -radius; i <= radius; i++) {
+            for (int j = -radius; j <= radius; j++) {
+                if (i * i + j * j <= radius * radius) {
+                    guiGraphics.fill(centerX + i, centerY + j, centerX + i + 1, centerY + j + 1, color);
+                }
+            }
+        }
+    }
+
+    private void drawFrostedGlassBackground(GuiGraphics guiGraphics, int x, int y, int width, int height, int radius) {
+        drawRoundedRect(guiGraphics, x, y, width, height, radius, 0xDDFAFAFA);
+        drawRoundedRect(guiGraphics, x + 1, y + 1, width - 2, height - 2, radius - 1, 0x40FFFFFF);
+        drawRoundedRect(guiGraphics, x + 2, y + 2, width - 4, height / 2 - 2, radius - 2, SHADOW_LIGHT);
+    }
+
+    private void drawGradientBorder(GuiGraphics guiGraphics, int x, int y, int width, int height, int radius) {
+        for (int i = 0; i < 3; i++) {
+            float ratio = i / 2f;
+            int color = lerpColor(ACCENT_PRIMARY, ACCENT_SECONDARY, ratio);
+            guiGraphics.fill(x + radius, y + i, x + width - radius, y + i + 1, color);
+        }
+        for (int i = 0; i < 3; i++) {
+            float ratio = i / 2f;
+            int color = lerpColor(ACCENT_SECONDARY, ACCENT_PRIMARY, ratio);
+            guiGraphics.fill(x + radius, y + height - 3 + i, x + width - radius, y + height - 2 + i, color);
+        }
+        for (int i = 0; i < 3; i++) {
+            guiGraphics.fill(x + i, y + radius, x + i + 1, y + height - radius, ACCENT_PRIMARY);
+        }
+        for (int i = 0; i < 3; i++) {
+            guiGraphics.fill(x + width - 3 + i, y + radius, x + width - 2 + i, y + height - radius, ACCENT_SECONDARY);
+        }
+    }
+
+    private void drawGradientLine(GuiGraphics guiGraphics, int x1, int y, int x2, int y2, int color1, int color2) {
+        int length = x2 - x1;
+        for (int i = 0; i < length; i++) {
+            float ratio = i / (float)length;
+            int color = lerpColor(color1, color2, ratio);
+            guiGraphics.fill(x1 + i, y, x1 + i + 1, y + 1, color);
+        }
+    }
+
+    private void drawStarIcon(GuiGraphics guiGraphics, int x, int y, int color) {
+        guiGraphics.fill(x + 4, y, x + 6, y + 1, color);
+        guiGraphics.fill(x + 3, y + 1, x + 7, y + 2, color);
+        guiGraphics.fill(x + 2, y + 2, x + 8, y + 3, color);
+        guiGraphics.fill(x + 1, y + 3, x + 9, y + 4, color);
+        guiGraphics.fill(x + 2, y + 4, x + 8, y + 5, color);
+        guiGraphics.fill(x + 3, y + 5, x + 7, y + 6, color);
+        guiGraphics.fill(x + 4, y + 6, x + 6, y + 7, color);
+        guiGraphics.fill(x + 3, y + 7, x + 4, y + 8, color);
+        guiGraphics.fill(x + 5, y + 7, x + 6, y + 8, color);
+    }
+
+    private int lerpColor(int color1, int color2, float ratio) {
+        int a1 = (color1 >> 24) & 0xFF;
+        int r1 = (color1 >> 16) & 0xFF;
+        int g1 = (color1 >> 8) & 0xFF;
+        int b1 = color1 & 0xFF;
+
+        int a2 = (color2 >> 24) & 0xFF;
+        int r2 = (color2 >> 16) & 0xFF;
+        int g2 = (color2 >> 8) & 0xFF;
+        int b2 = color2 & 0xFF;
+
+        int a = (int)(a1 + (a2 - a1) * ratio);
+        int r = (int)(r1 + (r2 - r1) * ratio);
+        int g = (int)(g1 + (g2 - g1) * ratio);
+        int b = (int)(b1 + (b2 - b1) * ratio);
+
+        return (a << 24) | (r << 16) | (g << 8) | b;
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/screen/SingleplayerSharePromptScreen.java
+++ b/src/main/java/firefly520/fireflymc/client/screen/SingleplayerSharePromptScreen.java
@@ -13,8 +13,6 @@ import javax.annotation.Nonnull;
 
 /**
  * 单人世界公开联机确认弹窗。
- *
- * 阶段一仅负责用户确认、调用 openToLAN 并展示 LAN 端口；公开大厅和中继将在后续阶段接入。
  */
 public class SingleplayerSharePromptScreen extends Screen {
     private static final int ACCENT_PRIMARY = 0xFFFF69B4;
@@ -93,15 +91,16 @@ public class SingleplayerSharePromptScreen extends Screen {
 
         int textX = dialogX + 34;
         int textY = separatorY + 78;
-        guiGraphics.drawString(this.font, "开启后，其他安装 FireflyMC 的玩家将可在多人列表看到并加入。", textX, textY, TEXT_SECONDARY, false);
-        guiGraphics.drawString(this.font, "阶段一会先打开本机 LAN 端口并记录端口，暂不接入中继大厅。", textX, textY + 18, TEXT_SECONDARY, false);
-        guiGraphics.drawString(this.font, "请注意：公开房间后陌生玩家可能进入并影响你的存档。", textX, textY + 36, WARNING_COLOR, false);
+        guiGraphics.drawString(this.font, "开启后，房间会发布到 FireflyMC 联机大厅。", textX, textY, TEXT_SECONDARY, false);
+        guiGraphics.drawString(this.font, "其他安装 FireflyMC 的玩家可通过中继直接加入，无需密码。", textX, textY + 18, TEXT_SECONDARY, false);
+        guiGraphics.drawString(this.font, "你退出世界后房间会自动关闭，加入中的玩家也会断开。", textX, textY + 36, TEXT_SECONDARY, false);
+        guiGraphics.drawString(this.font, "请注意：公开房间后陌生玩家可能进入并影响你的存档。", textX, textY + 54, WARNING_COLOR, false);
 
         int port = ClientState.singleplayerRelayLanPort;
         if (ClientState.isSingleplayerRelayHosting && port > 0) {
-            drawCentered(guiGraphics, "LAN 已准备，端口：" + port, textY + 70, 0xFF228B22);
+            drawCentered(guiGraphics, "房间已发布到联机大厅，等待玩家加入", textY + 84, 0xFF228B22);
         } else if (ClientState.isSingleplayerRelayHosting) {
-            drawCentered(guiGraphics, "LAN 已请求开启，正在等待端口读取", textY + 70, 0xFF228B22);
+            drawCentered(guiGraphics, "正在发布到 FireflyMC 联机大厅...", textY + 84, 0xFF228B22);
         }
 
         super.render(guiGraphics, mouseX, mouseY, partialTick);

--- a/src/main/java/firefly520/fireflymc/network/ModPayloadHandler.java
+++ b/src/main/java/firefly520/fireflymc/network/ModPayloadHandler.java
@@ -28,6 +28,10 @@ public class ModPayloadHandler {
     public static void handleHandshakeReply(ModHandshakeReplyPayload payload, IPayloadContext context) {
         context.enqueueWork(() -> {
             if (context.player() instanceof ServerPlayer serverPlayer) {
+                if (serverPlayer.server.isSingleplayer()) {
+                    return;
+                }
+
                 if (payload.modVersion().equals(FireflyMCMod.VERSION)) {
                     VERIFIED_PLAYERS.put(serverPlayer.getUUID(), true);
                     // 取消验证超时任务
@@ -53,6 +57,10 @@ public class ModPayloadHandler {
     public static void handleConfirmRules(ConfirmRulesPayload payload, IPayloadContext context) {
         context.enqueueWork(() -> {
             if (context.player() instanceof ServerPlayer serverPlayer) {
+                if (serverPlayer.server.isSingleplayer()) {
+                    return;
+                }
+
                 UUID playerUuid = serverPlayer.getUUID();
                 // 取消超时任务
                 ModEventHandler.cancelInvulnerabilityTimeout(playerUuid);

--- a/src/main/resources/MANIFEST.MF
+++ b/src/main/resources/MANIFEST.MF
@@ -3,7 +3,7 @@ Specification-Title: fireflymc
 Specification-Vendor: FireflyMC
 Specification-Version: 1
 Implementation-Title: Minecraft-Sakura
-Implementation-Version: 2.4.1
+Implementation-Version: 2.5.0
 Implementation-Vendor: FireflyMC
 Implementation-Timestamp: 2026-03-14T00:54:41+0800
 


### PR DESCRIPTION
Enhance the LAN bridge mod with guest joining capabilities, P2P connection support, and improved relay management. Update documentation for Minecraft 1.21.1 / NeoForge 21.1.219, including event handling and UI components. Bump version to 2.5.0 to reflect these changes.

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 为 Minecraft LAN 桥接模组新增了**访客加入**与 **P2P 中继支持**，并更新相关文档。代码变更量庞大（+3920/-44），主要集中在新增中继与 P2P 通信模块。后续提交对日志中的 P2P 地址进行了脱敏处理，提升了安全性。

### 主要改动列表
- **新增访客加入功能**：实现 `RelayGuestJoiner`、`RelayGuestProxy`，允许访客通过中继服务器加入 LAN 世界
- **新增 P2P 支持**：添加 `P2PConnectionManager`、`ReliableUdpChannel`、`ReorderBuffer` 等，实现可靠 UDP 点对点通信
- **新增主机桥接**：`RelayHostBridge` 与 `P2PHostBridge` 负责主机端连接转发
- **中继大厅系统**：新增 `RelayLobbyWebSocketClient`、`RelayLobbyScreen` 等，支持大厅列表与消息交互
- **单人生存模式中继**：`SingleplayerRelayManager` 与事件监听，让单机世界也能被远程访客加入
- **安全与日志优化**：对中继日志中的 P2P 地址进行脱敏（sanitize），防止敏感信息泄露。具体修改位于 `RelayLobbyWebSocketClient`（+2/-2 行）
- **配置与界面更新**：`Config.java` 新增配置项，`HUDRenderer` 简化，新增分享提示界面

### 影响范围
- **核心玩法**：单人生存/局域网世界现可被外部访客经中继或 P2P 加入
- **网络层**：新增 WebSocket 中继通信与 UDP P2P 穿透能力
- **客户端 UI**：新增大厅界面和分享提示界面
- **安全**：日志中敏感地址已做脱敏处理
- **兼容性**：需配合中继服务端使用，原有 LAN 功能不受影响

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 🔗 Sakura AI Reviewer 依赖图

```mermaid
graph TD
    FireflyMCMod["FireflyMCMod.java"]
    SingleplayerRelayClientEvents["SingleplayerRelayClientEvents.java"]
    SingleplayerRelayManager["SingleplayerRelayManager.java"]
    RelayLobbyScreen["RelayLobbyScreen.java"]
    SingleplayerSharePromptScreen["SingleplayerSharePromptScreen.java"]
    RelayGuestJoiner["RelayGuestJoiner.java"]
    RelayLobbyWebSocketClient["RelayLobbyWebSocketClient.java"]
    P2PConnectionManager["P2PConnectionManager.java"]
    RelayLobbyMessage["RelayLobbyMessage.java"]

    FireflyMCMod --> SingleplayerRelayClientEvents
    SingleplayerRelayClientEvents --> SingleplayerSharePromptScreen
    SingleplayerRelayClientEvents --> RelayLobbyScreen
    SingleplayerRelayManager --> P2PConnectionManager
    RelayLobbyScreen --> RelayLobbyWebSocketClient
    RelayLobbyScreen --> RelayGuestJoiner
    RelayLobbyWebSocketClient --> P2PConnectionManager
    RelayLobbyWebSocketClient --> RelayLobbyMessage

    FireflyMCMod -.-> Config["Config.java"]
    FireflyMCMod -.-> UpdateChecker["UpdateChecker.java"]
    ModEventHandler["ModEventHandler.java"] -.-> ModPayloadHandler["ModPayloadHandler.java"]
    RelayGuestJoiner -.-> P2PConnectionManager
    RelayLobbyMessage -.-> FireflyMCMod

    style FireflyMCMod stroke-width:2px
    style SingleplayerRelayClientEvents stroke-width:2px
    style SingleplayerRelayManager stroke-width:2px
    style RelayLobbyScreen stroke-width:2px
    style SingleplayerSharePromptScreen stroke-width:2px
    style RelayGuestJoiner stroke-width:2px
    style RelayLobbyWebSocketClient stroke-width:2px
    style P2PConnectionManager stroke-width:2px
    style RelayLobbyMessage stroke-width:2px
```

<!-- sakura-ai-depgraph-end -->