### PR TITLE
feat(relay): Add relay lobby room entries to multiplayer server list

### DIFF
--- a/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyState.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayLobbyState.java
@@ -10,6 +10,7 @@ public final class RelayLobbyState {
     private static final List<RelayLobbyRoom> ROOMS = new ArrayList<>();
     private static String statusMessage = "尚未刷新";
     private static boolean refreshing = false;
+    private static long revision = 0;
 
     private RelayLobbyState() {
     }
@@ -26,6 +27,7 @@ public final class RelayLobbyState {
         ROOMS.clear();
         ROOMS.addAll(rooms);
         refreshing = false;
+        revision++;
         statusMessage = rooms.isEmpty() ? "暂无公开单人世界" : "已加载 " + rooms.size() + " 个公开单人世界";
     }
 
@@ -40,5 +42,9 @@ public final class RelayLobbyState {
 
     public static synchronized List<RelayLobbyRoom> rooms() {
         return List.copyOf(ROOMS);
+    }
+
+    public static synchronized long revision() {
+        return revision;
     }
 }

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayServerEntry.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayServerEntry.java
@@ -1,0 +1,110 @@
+package firefly520.fireflymc.client.relay;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.Util;
+import net.minecraft.client.gui.Font;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
+import net.minecraft.client.gui.screens.multiplayer.ServerSelectionList;
+import net.minecraft.network.chat.Component;
+import net.minecraft.util.FormattedCharSequence;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+
+import java.util.List;
+
+/**
+ * 联机大厅房间在原版服务器列表中的自定义条目。
+ * <p>
+ * 外观接近原版 OnlineServerEntry，但点击时走 RelayGuestJoiner.join() 流程，
+ * 不写入 servers.dat。
+ */
+@OnlyIn(Dist.CLIENT)
+public class RelayServerEntry extends ServerSelectionList.Entry {
+
+    private static final int ACCENT_PRIMARY = 0xFFFF69B4;
+    private static final int ACCENT_SECONDARY = 0xFFFF1493;
+    private static final int TEXT_SECONDARY = 0xFF888888;
+
+    private final JoinMultiplayerScreen screen;
+    private final Minecraft minecraft;
+    private final RelayLobbyRoom room;
+    private long lastClickTime;
+
+    public RelayServerEntry(JoinMultiplayerScreen screen, RelayLobbyRoom room) {
+        this.screen = screen;
+        this.minecraft = Minecraft.getInstance();
+        this.room = room;
+    }
+
+    @Override
+    public void render(
+            GuiGraphics guiGraphics,
+            int index,
+            int top,
+            int left,
+            int width,
+            int height,
+            int mouseX,
+            int mouseY,
+            boolean hovering,
+            float partialTick
+    ) {
+        Font font = this.minecraft.font;
+
+        // 服务器名称 — 使用房间世界名
+        String displayName = "[FireflyMC] " + room.worldName();
+        guiGraphics.drawString(font, displayName, left + 32 + 3, top + 1, ACCENT_PRIMARY, false);
+
+        // 描述行 — 房主 + 玩家数 + P2P/中继
+        String desc = "房主: " + room.hostPlayerName();
+        List<FormattedCharSequence> descLines = font.split(Component.literal(desc), width - 32 - 2);
+        for (int i = 0; i < Math.min(descLines.size(), 1); i++) {
+            guiGraphics.drawString(font, descLines.get(i), left + 32 + 3, top + 12 + 9 * i, TEXT_SECONDARY, false);
+        }
+
+        // 第三行 — 版本 + 连接方式
+        String versionInfo = "MC " + room.minecraftVersion()
+                + "  " + (room.p2pSupported() ? "P2P优先" : "中继")
+                + "  " + room.currentPlayers() + "/" + room.maxPlayers() + " 玩家";
+        guiGraphics.drawString(font, versionInfo, left + 32 + 3, top + 12 + 11, 3158064, false);
+
+        // 绘制图标区域背景（粉色渐变方块，标识为 FireflyMC 房间）
+        guiGraphics.fill(left, top, left + 32, top + 32, 0x40FF69B4);
+        guiGraphics.fill(left + 2, top + 2, left + 30, top + 30, 0x60FF1493);
+
+        // 绘制 "FF" 标识
+        int iconCenterX = left + 16;
+        int iconCenterY = top + 16;
+        guiGraphics.drawString(font, "FF", iconCenterX - font.width("FF") / 2, iconCenterY - 4, 0xFFFFFF, false);
+
+        // 悬停效果
+        if (hovering) {
+            guiGraphics.fill(left, top, left + 32, top + 32, -1601138544);
+        }
+    }
+
+    @Override
+    public boolean mouseClicked(double mouseX, double mouseY, int button) {
+        this.screen.setSelected(this);
+        if (Util.getMillis() - this.lastClickTime < 250L) {
+            // 双击 — 通过桥接层加入
+            RelayServerListBridge.joinRoom(this.screen, this.room);
+        }
+        this.lastClickTime = Util.getMillis();
+        return super.mouseClicked(mouseX, mouseY, button);
+    }
+
+    public RelayLobbyRoom getRoom() {
+        return this.room;
+    }
+
+    @Override
+    public Component getNarration() {
+        return Component.translatable("narrator.select",
+                Component.empty()
+                        .append(Component.literal("[FireflyMC] " + room.worldName()))
+                        .append(Component.literal(" 房主: " + room.hostPlayerName()))
+                        .append(Component.literal(" " + room.currentPlayers() + "/" + room.maxPlayers())));
+    }
+}

--- a/src/main/java/firefly520/fireflymc/client/relay/RelayServerListBridge.java
+++ b/src/main/java/firefly520/fireflymc/client/relay/RelayServerListBridge.java
@@ -1,0 +1,99 @@
+package firefly520.fireflymc.client.relay;
+
+import firefly520.fireflymc.Config;
+import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
+import net.neoforged.api.distmarker.Dist;
+import net.neoforged.api.distmarker.OnlyIn;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 联机大厅房间到原版服务器列表的桥接层。
+ * <p>
+ * 负责将 RelayLobbyState 中的房间转换为 RelayServerEntry 列表，
+ * 由 ServerSelectionListMixin 调用 addEntry 注入到原版列表中。
+ */
+@OnlyIn(Dist.CLIENT)
+public final class RelayServerListBridge {
+    private static final Logger LOGGER = LoggerFactory.getLogger(RelayServerListBridge.class);
+
+    /** 上次注入时的 revision，用于避免重复注入 */
+    private static long lastInjectedRevision = -1;
+
+    /** 当前已注入的条目快照，用于去重 */
+    private static final List<RelayServerEntry> injectedEntries = new ArrayList<>();
+
+    private RelayServerListBridge() {
+    }
+
+    /**
+     * 获取需要注入到原版服务器列表的联机大厅房间条目。
+     * <p>
+     * 由 ServerSelectionListMixin 在 refreshEntries() 后调用。
+     * 只有当房间列表 revision 变化时才重新构建条目。
+     *
+     * @param screen 当前多人游戏界面
+     * @return 需要注入的条目列表（不可变）
+     */
+    public static List<RelayServerEntry> getEntriesToInject(JoinMultiplayerScreen screen) {
+        if (!Config.CLIENT.SINGLEPLAYER_RELAY_ENABLED.get()) {
+            return Collections.emptyList();
+        }
+
+        long currentRevision = RelayLobbyState.revision();
+        if (currentRevision == lastInjectedRevision && !injectedEntries.isEmpty()) {
+            return Collections.unmodifiableList(injectedEntries);
+        }
+
+        // revision 变了，重新构建
+        lastInjectedRevision = currentRevision;
+        injectedEntries.clear();
+
+        List<RelayLobbyRoom> rooms = RelayLobbyState.rooms();
+        for (RelayLobbyRoom room : rooms) {
+            injectedEntries.add(new RelayServerEntry(screen, room));
+        }
+
+        if (!rooms.isEmpty()) {
+            LOGGER.debug("[FireflyMC] 已向原版服务器列表注入 {} 个联机大厅房间", rooms.size());
+        }
+
+        return Collections.unmodifiableList(injectedEntries);
+    }
+
+    /**
+     * 请求刷新联机大厅列表。
+     * <p>
+     * 由 JoinMultiplayerScreenMixin 在屏幕初始化时调用。
+     */
+    public static void requestLobbyRefresh() {
+        if (!Config.CLIENT.SINGLEPLAYER_RELAY_ENABLED.get()) {
+            return;
+        }
+        RelayLobbyWebSocketClient.getInstance().requestLobbyList();
+    }
+
+    /**
+     * 加入联机大厅房间。
+     * <p>
+     * 由 RelayServerEntry 双击或选中后点击"加入服务器"时调用。
+     *
+     * @param screen 当前多人游戏界面
+     * @param room   要加入的房间
+     */
+    public static void joinRoom(JoinMultiplayerScreen screen, RelayLobbyRoom room) {
+        RelayGuestJoiner.join(screen, room);
+    }
+
+    /**
+     * 重置注入状态（屏幕关闭时调用）。
+     */
+    public static void reset() {
+        lastInjectedRevision = -1;
+        injectedEntries.clear();
+    }
+}

--- a/src/main/java/firefly520/fireflymc/mixin/JoinMultiplayerScreenMixin.java
+++ b/src/main/java/firefly520/fireflymc/mixin/JoinMultiplayerScreenMixin.java
@@ -1,0 +1,70 @@
+package firefly520.fireflymc.mixin;
+
+import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
+import net.minecraft.client.gui.screens.multiplayer.ServerSelectionList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import firefly520.fireflymc.client.relay.RelayServerEntry;
+import firefly520.fireflymc.client.relay.RelayServerListBridge;
+
+/**
+ * Mixin：在原版多人游戏界面中处理联机大厅房间的加入。
+ * <p>
+ * 1. 屏幕初始化后请求大厅列表刷新。
+ * 2. 拦截 joinSelectedServer()，当选中的是联机大厅房间时走 RelayGuestJoiner。
+ * 3. 屏幕关闭时重置桥接层状态。
+ * <p>
+ * 注意：onSelectedChange() 不需要拦截，因为原版逻辑已正确处理：
+ * RelayServerEntry 不是 OnlineServerEntry，所以编辑/删除按钮会自动禁用。
+ */
+@Mixin(JoinMultiplayerScreen.class)
+public class JoinMultiplayerScreenMixin {
+
+    @Shadow(remap = false)
+    protected ServerSelectionList serverSelectionList;
+
+    /**
+     * 屏幕初始化后请求联机大厅列表刷新。
+     */
+    @Inject(
+        method = "init",
+        at = @At("TAIL"),
+        remap = false
+    )
+    private void fireflymc$onInit(CallbackInfo ci) {
+        RelayServerListBridge.requestLobbyRefresh();
+    }
+
+    /**
+     * 拦截 joinSelectedServer()。
+     * 当选中的是 RelayServerEntry 时，走 RelayGuestJoiner.join() 而非原版连接。
+     */
+    @Inject(
+        method = "joinSelectedServer",
+        at = @At("HEAD"),
+        cancellable = true,
+        remap = false
+    )
+    private void fireflymc$onJoinSelected(CallbackInfo ci) {
+        ServerSelectionList.Entry selected = this.serverSelectionList.getSelected();
+        if (selected instanceof RelayServerEntry relayEntry) {
+            RelayServerListBridge.joinRoom((JoinMultiplayerScreen) (Object) this, relayEntry.getRoom());
+            ci.cancel();
+        }
+    }
+
+    /**
+     * 屏幕关闭时重置桥接层状态。
+     */
+    @Inject(
+        method = "removed",
+        at = @At("TAIL"),
+        remap = false
+    )
+    private void fireflymc$onRemoved(CallbackInfo ci) {
+        RelayServerListBridge.reset();
+    }
+}

--- a/src/main/java/firefly520/fireflymc/mixin/ServerSelectionListMixin.java
+++ b/src/main/java/firefly520/fireflymc/mixin/ServerSelectionListMixin.java
@@ -1,0 +1,50 @@
+package firefly520.fireflymc.mixin;
+
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.components.ObjectSelectionList;
+import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
+import net.minecraft.client.gui.screens.multiplayer.ServerSelectionList;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import firefly520.fireflymc.client.relay.RelayServerEntry;
+import firefly520.fireflymc.client.relay.RelayServerListBridge;
+
+import java.util.List;
+
+/**
+ * Mixin：在原版服务器列表刷新条目后，追加联机大厅房间。
+ * <p>
+ * 注入点：ServerSelectionList.refreshEntries() 的 TAIL。
+ * 每次原版列表重建（updateOnlineServers / updateNetworkServers）后都会触发。
+ * <p>
+ * 继承 ObjectSelectionList 以获得 addEntry 的 protected 访问权限。
+ */
+@Mixin(ServerSelectionList.class)
+public abstract class ServerSelectionListMixin extends ObjectSelectionList<ServerSelectionList.Entry> {
+
+    // 构造函数由 Mixin 框架处理，不需要显式实现
+    private ServerSelectionListMixin() { super(null, 0, 0, 0, 0); }
+
+    /**
+     * 在 refreshEntries() 末尾注入联机大厅房间条目。
+     * refreshEntries() 是 private 方法，Mojang 映射名不变。
+     */
+    @Inject(
+        method = "refreshEntries",
+        at = @At("TAIL"),
+        remap = false
+    )
+    private void fireflymc$afterRefreshEntries(CallbackInfo ci) {
+        Minecraft mc = Minecraft.getInstance();
+        if (!(mc.screen instanceof JoinMultiplayerScreen screen)) {
+            return;
+        }
+
+        List<RelayServerEntry> entries = RelayServerListBridge.getEntriesToInject(screen);
+        for (RelayServerEntry entry : entries) {
+            this.addEntry(entry);
+        }
+    }
+}

--- a/src/main/resources/mixins.fireflymc.json
+++ b/src/main/resources/mixins.fireflymc.json
@@ -5,7 +5,10 @@
   "mixins": [
     "ServerChatMixin"
   ],
-  "client": [],
+  "client": [
+    "ServerSelectionListMixin",
+    "JoinMultiplayerScreenMixin"
+  ],
   "server": ["ServerChatMixin"],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
- Add revision counter to RelayLobbyState and increment after each room update
- Add revision() getter method to RelayLobbyState
- Create RelayServerEntry class to render relay rooms with custom UI in server list
- Implement mouse click handling with double-click to join via RelayServerListBridge
- Create RelayServerListBridge to convert rooms to entries and cache based on revision
- Add conditional injection when SINGLEPLAYER_RELAY_ENABLED config is true

<!-- sakura-ai-summary-start -->

## 🌸 Sakura AI Reviewer的总结

### 变更概览
本次 PR 为中继（Relay）功能新增了多人游戏服务器列表的入口支持，允许用户在游戏内直接浏览和连接中继大厅房间。主要通过新增类和混入（Mixin）实现，代码变更集中在客户端逻辑。

### 主要改动列表
1. **新增功能**：
   - `RelayServerEntry`：定义中继服务器条目，包含大厅房间信息。
   - `RelayServerListBridge`：桥接中继服务器列表与游戏原生服务器列表。
   - `RelayLobbyState`：扩展中继大厅状态管理（+6 行）。
2. **集成与混入**：
   - `JoinMultiplayerScreenMixin`：在多人游戏加入界面添加中继服务器列表支持（+70 行）。
   - `ServerSelectionListMixin`：在服务器选择列表中渲染中继条目（+50 行）。
3. **其他**：无重大重构或 Bug 修复，纯功能新增。

### 影响范围
- **客户端**：仅影响 Minecraft 客户端的多人游戏界面，用户可直接在服务器列表中看到并连接中继大厅房间。
- **服务器端**：无变更，不影响现有服务器逻辑。
- **兼容性**：新增功能，不破坏现有功能，但需确保中继服务端已配置。

<!-- sakura-ai-summary-end -->

<!-- sakura-ai-depgraph-start -->

## 依赖图

```mermaid
graph TD
    N1["src/main/java/firefly520/fireflymc/client/relay/RelayServerEntry.java"]
    N2["src/main/java/firefly520/fireflymc/client/relay/RelayServerListBridge.java"]
    N3["src/main/java/firefly520/fireflymc/mixin/JoinMultiplayerScreenMixin.java"]
    N4["src/main/java/firefly520/fireflymc/mixin/ServerSelectionListMixin.java"]
    N5["src/main/java/firefly520/fireflymc/client/relay/RelayLobbyState.java"]
    N3 --> N1
    N3 --> N2
    N4 --> N1
    N4 --> N2
```

<!-- sakura-ai-depgraph-end -->